### PR TITLE
fix token expired event

### DIFF
--- a/examples/context/package.json
+++ b/examples/context/package.json
@@ -19,5 +19,11 @@
   },
   "scripts": {
     "start": "react-scripts start"
-  }
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
 }

--- a/packages/context/src/Context/AuthenticationContext.container.spec.js
+++ b/packages/context/src/Context/AuthenticationContext.container.spec.js
@@ -24,6 +24,7 @@ describe('AuthContext tests suite', () => {
   beforeEach(() => {
     userManagerMock = {
       removeUser: jest.fn(),
+      signinSilent: jest.fn(),
     };
     // eslint-disable-next-line
     services.authenticateUser = jest.fn(() => () => jest.fn());
@@ -68,6 +69,16 @@ describe('AuthContext tests suite', () => {
     });
   });
 
+  it('should set state and call silentSignin to location when call onAccessTokenExpired', () => {
+    container.onAccessTokenExpired(propsMock)();
+    expect(propsMock.setOidcState).toBeCalledWith({
+      ...previousOidcState,
+      isLoading: false,
+      oidcUser: null,
+    });
+    expect(userManagerMock.signinSilent).toBeCalled();
+  });
+
   it('should set default state when call setDefaultState', () => {
     const defaultState = container.setDefaultState(propsMock);
     expect(services.authenticationService).toBeCalledWith(configurationMock);
@@ -87,7 +98,10 @@ describe('AuthContext tests suite', () => {
       isLoading: true,
       oidcUser: null,
     });
-    expect(services.authenticateUser).toBeCalledWith(userManagerMock, 'locationMock');
+    expect(services.authenticateUser).toBeCalledWith(
+      userManagerMock,
+      'locationMock',
+    );
   });
 
   it('should set state and call onUserUnload function when call logout', async () => {

--- a/packages/context/src/Services/oidcServices.js
+++ b/packages/context/src/Services/oidcServices.js
@@ -1,8 +1,11 @@
 import { oidcLog } from './loggerService';
 
-export const isRequireAuthentication = (oidcUser, isForce) => isForce || !oidcUser;
+export const isRequireAuthentication = (oidcUser, isForce) =>
+  isForce || !oidcUser || oidcUser.expired;
 
-export const authenticateUser = (userManager, location) => async (isForce = false) => {
+export const authenticateUser = (userManager, location) => async (
+  isForce = false,
+) => {
   if (!userManager || !userManager.getUser) {
     return;
   }
@@ -25,4 +28,5 @@ export const logoutUser = async userManager => {
   }
 };
 
-export const signinSilent = getUserManager => () => getUserManager().signinSilent();
+export const signinSilent = getUserManager => () =>
+  getUserManager().signinSilent();


### PR DESCRIPTION
## A picture tells a thousand words

## Before this PR
After a silent failure, token expired is stuck in his own state. Login is no longer possible

## After this PR
Login  with a expired token possible + silentsignin when token expired

Close #77 
