### PR TITLE
fix(react-oidc-context) Add react-router to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11639,8 +11639,7 @@
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "braces": {
           "version": "2.3.2",
@@ -11903,8 +11902,7 @@
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "micromatch": {
           "version": "3.1.10",
@@ -13630,6 +13628,7 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
       "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
       "dev": true,
+      "optional": true,
       "requires": {
         "commander": "~2.17.1",
         "source-map": "~0.6.1"

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "oidc-client": "^1.5.2",
     "prop-types": "~15.6.2",
+    "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
     "recompose": "^0.30.0"
   },


### PR DESCRIPTION
react-router is used in the package [@axa-fr/react-oidc-context](https://github.com/AxaGuilDEv/react-oidc/blob/master/packages/context#readme).
 https://github.com/AxaGuilDEv/react-oidc/blob/c9ef58e7c2e328b30d9cd6e8201ffd462809f5e7/packages/context/src/Routes/AuthenticationRoutes.js#L2

However it's not listed as a dependency in the project.