### PR TITLE
English - change all instances of "authentified" to be "authenticated"

### DIFF
--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -53,7 +53,7 @@ render(<App />, document.getElementById('root'));
 
 ```javascript
 const propTypes = {
-  notAuthentified: PropTypes.node, // react component displayed during authentication
+  notAuthenticated: PropTypes.node, // react component displayed during authentication
   notAuthorized: PropTypes.node, // react component displayed in case user is not Authorised
   authenticating: PropTypes.node, // react component displayed when about to redirect user to be authenticated
   configuration: PropTypes.shape({

--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -20,7 +20,7 @@ The default routes used internally :
 
 - www.your-app.fr/authentication/callback
 - www.your-app.fr/authentication/silent_callback
-- www.your-app.fr/authentication/not-authentified
+- www.your-app.fr/authentication/not-authenticated
 - www.your-app.fr/authentication/not-authorized
 
 ```javascript
@@ -162,7 +162,7 @@ export default () => (
 ### How to consume : HOC method (Layout/Header.js)
 
 "withOidcUser" function act like "AuthenticationConsumer" below.
-"OidcSecure" component trigger authentication in case user is not authentified. So, the children of that component can be accessible only once you are connected.
+"OidcSecure" component trigger authentication in case user is not authenticated. So, the children of that component can be accessible only once you are connected.
 
 ```javascript
 import React from 'react';
@@ -182,7 +182,7 @@ export default withOidcUser(Admin);
 
 ### How to secure a component (Router/Routes.js)
 
-"withOidcSecure" act the same as "OidcSecure" it also trigger authentication in case user is not authentified.
+"withOidcSecure" act the same as "OidcSecure" it also trigger authentication in case user is not authenticated.
 
 ```javascript
 import React from 'react';

--- a/packages/context/src/Callback/Callback.container.js
+++ b/packages/context/src/Callback/Callback.container.js
@@ -16,7 +16,7 @@ export const onRedirectSuccess = ({ history }) => user => {
 export const onRedirectError = ({ history }) => error => {
   const { message } = error;
   oidcLog.error(`There was an error handling the token callback: ${error.message}`);
-  history.push(`/authentication/not-authentified?message=${message}`);
+  history.push(`/authentication/not-authenticated?message=${message}`);
 };
 
 export const componentDidMountFunction = async props => {

--- a/packages/context/src/Callback/Callback.container.spec.js
+++ b/packages/context/src/Callback/Callback.container.spec.js
@@ -27,7 +27,7 @@ describe('Callback container tests suite', () => {
 
   it('Should push on error message when onError is call', () => {
     container.onRedirectError({ history })({ message: 'errorMessage' });
-    expect(history.push).toBeCalledWith('/authentication/not-authentified?message=errorMessage');
+    expect(history.push).toBeCalledWith('/authentication/not-authenticated?message=errorMessage');
   });
 
   it('Should call signinRedirectCallback and onRedirectSuccess when call componentDidMount', async () => {

--- a/packages/context/src/Context/AuthenticationContext.container.js
+++ b/packages/context/src/Context/AuthenticationContext.container.js
@@ -21,7 +21,7 @@ import AuthenticationProviderComponent from './AuthenticationContext';
 import { AuthenticationContext } from './AuthenticationContextCreator';
 
 const propTypes = {
-  notAuthentified: PropTypes.node,
+  notAuthenticated: PropTypes.node,
   notAuthorized: PropTypes.node,
   configuration: PropTypes.shape({
     client_id: PropTypes.string.isRequired,
@@ -45,7 +45,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  notAuthentified: null,
+  notAuthenticated: null,
   notAuthorized: null,
   isEnabled: true,
   loggerLevel: 0,

--- a/packages/context/src/Context/AuthenticationContext.js
+++ b/packages/context/src/Context/AuthenticationContext.js
@@ -4,7 +4,7 @@ import { AuthenticationContext } from './AuthenticationContextCreator';
 import { OidcRoutes } from '../Routes';
 
 const propTypes = {
-  notAuthentified: PropTypes.node,
+  notAuthenticated: PropTypes.node,
   notAuthorized: PropTypes.node,
   authenticating: PropTypes.node,
   isLoading: PropTypes.bool.isRequired,
@@ -17,7 +17,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  notAuthentified: null,
+  notAuthenticated: null,
   notAuthorized: null,
   authenticating: null,
   isEnabled: true
@@ -30,7 +30,7 @@ const AuthenticationProviderComponent = ({
   error,
   login,
   logout,
-  notAuthentified,
+  notAuthenticated,
   notAuthorized,
   authenticating,
   children
@@ -46,7 +46,7 @@ const AuthenticationProviderComponent = ({
       isEnabled
     }}
   >
-    <OidcRoutes notAuthentified={notAuthentified} notAuthorized={notAuthorized}>
+    <OidcRoutes notAuthenticated={notAuthenticated} notAuthorized={notAuthorized}>
       {children}
     </OidcRoutes>
   </AuthenticationContext.Provider>

--- a/packages/context/src/Routes/AuthenticationRoutes.js
+++ b/packages/context/src/Routes/AuthenticationRoutes.js
@@ -10,7 +10,7 @@ const AuthenticationRoutes = (notAuthenticated, notAuthorized) => ({ match }) =>
     <Switch>
       <Route path={`${match.url}/callback`} component={Callback} />
       <Route path={`${match.url}/silent_callback`} component={SilentCallback} />
-      <Route path={`${match.url}/not-authentified`} component={notAuthenticatedComponent} />
+      <Route path={`${match.url}/not-authenticated`} component={notAuthenticatedComponent} />
       <Route path={`${match.url}/not-authorized`} component={notAuthorizedComponent} />
     </Switch>
   );

--- a/packages/context/src/Routes/OidcRoutes.js
+++ b/packages/context/src/Routes/OidcRoutes.js
@@ -4,22 +4,22 @@ import PropTypes from 'prop-types';
 import AuthenticationRoutes from './AuthenticationRoutes';
 
 const propTypes = {
-  notAuthentified: PropTypes.node,
+  notAuthenticated: PropTypes.node,
   notAuthorized: PropTypes.node,
   children: PropTypes.node,
 };
 
 const defaultProps = {
-  notAuthentified: null,
+  notAuthenticated: null,
   notAuthorized: null,
   children: null,
 };
 
-const OidcRoutes = ({ notAuthentified, notAuthorized, children }) => (
+const OidcRoutes = ({ notAuthenticated, notAuthorized, children }) => (
   <Switch>
     <Route
       path="/authentication"
-      component={AuthenticationRoutes(notAuthentified, notAuthorized)}
+      component={AuthenticationRoutes(notAuthenticated, notAuthorized)}
     />
     <Route render={() => children} />
   </Switch>

--- a/packages/context/src/Routes/OidcRoutes.spec.js
+++ b/packages/context/src/Routes/OidcRoutes.spec.js
@@ -12,7 +12,7 @@ describe('Authenticating test suite', () => {
   it('renders correctly', () => {
     const props = {
       children: 'http://url.com',
-      notAuthentified: 'notAuthentified',
+      notAuthenticated: 'notAuthenticated',
       notAuthorized: 'notAuthorized',
     };
 

--- a/packages/context/src/Routes/__snapshots__/AuthenticationRoutes.spec.js.snap
+++ b/packages/context/src/Routes/__snapshots__/AuthenticationRoutes.spec.js.snap
@@ -12,7 +12,7 @@ exports[`Authenticating test suite renders correctly 1`] = `
   />
   <Route
     component="NotAuthenticated"
-    path="http://url.com/not-authentified"
+    path="http://url.com/not-authenticated"
   />
   <Route
     component="NotAuthorized"

--- a/packages/redux/README.md
+++ b/packages/redux/README.md
@@ -17,7 +17,7 @@ The library need it to manage and normalise http redirection.
  The default routes used internally :
  - www.your-app.fr/authentication/callback
 - www.your-app.fr/authentication/silent_callback
-- www.your-app.fr/authentication/not-authentified
+- www.your-app.fr/authentication/not-authenticated
 - www.your-app.fr/authentication/not-authorized
 
 

--- a/packages/redux/README.md
+++ b/packages/redux/README.md
@@ -71,7 +71,7 @@ The optional parameter "isEnabled" allows you to enable or disable authenticatio
 "Authentificationprovider" accept the following properties :
  ```javascript
 const propTypes = {
-  notAuthentified: PropTypes.node, // react component displayed during authentication
+  notAuthenticated: PropTypes.node, // react component displayed during authentication
   notAuthorized: PropTypes.node, // react component displayed in case user is not Authorised
   configuration: PropTypes.shape({
     client_id: PropTypes.string.isRequired, // oidc client configuration, the same as oidc client library used internally https://github.com/IdentityModel/oidc-client-js

--- a/packages/redux/src/AuthenticationCallback.js
+++ b/packages/redux/src/AuthenticationCallback.js
@@ -26,7 +26,7 @@ const AuthenticationCallback = ({ history, userManager }) => {
   const errorCallback = error => {
     const { message } = error;
     logError(`There was an error handling the token callback: ${message}`);
-    history.push(`/authentication/not-authentified?message=${message}`);
+    history.push(`/authentication/not-authenticated?message=${message}`);
   };
 
   return (

--- a/packages/redux/src/AuthenticationRoutes.js
+++ b/packages/redux/src/AuthenticationRoutes.js
@@ -15,7 +15,7 @@ const AuthenticationRoutes = (notAuthenticated, notAuthorized) => ({ match }) =>
         path={`${match.url}/signin-silent-callback`}
         component={AuthenticationSignSilentCallback}
       />
-      <Route path={`${match.url}/not-authentified`} component={notAuthenticatedComponent} />
+      <Route path={`${match.url}/not-authenticated`} component={notAuthenticatedComponent} />
       <Route path={`${match.url}/not-authorized`} component={notAuthorizedComponent} />
     </Switch>
   );

--- a/packages/redux/src/Oidc.js
+++ b/packages/redux/src/Oidc.js
@@ -6,7 +6,7 @@ import OidcRoutes from './OidcRoutes';
 import authenticationService, { getUserManager } from './authenticationService';
 
 const propTypes = {
-  notAuthentified: PropTypes.node,
+  notAuthenticated: PropTypes.node,
   notAuthorized: PropTypes.node,
   // eslint-disable-next-line
   configuration: PropTypes.object.isRequired,
@@ -16,7 +16,7 @@ const propTypes = {
 };
 
 export const OidcBase = props => {
-  const { isEnabled, children, store, notAuthentified, notAuthorized } = props;
+  const { isEnabled, children, store, notAuthenticated, notAuthorized } = props;
 
   if (!isEnabled) {
     return <Fragment>{children}</Fragment>;
@@ -25,7 +25,7 @@ export const OidcBase = props => {
   return (
     <OidcProvider store={store} userManager={getUserManager()}>
       <OidcRoutes
-        notAuthentified={notAuthentified}
+        notAuthenticated={notAuthenticated}
         notAuthorized={notAuthorized}
       >
         {children}
@@ -47,7 +47,7 @@ const lifecycleComponent = {
 };
 
 const defaultPropsObject = {
-  notAuthentified: null,
+  notAuthenticated: null,
   notAuthorized: null,
   isEnabled: true,
   children: null,

--- a/packages/redux/src/OidcRoutes.js
+++ b/packages/redux/src/OidcRoutes.js
@@ -4,22 +4,22 @@ import PropTypes from 'prop-types';
 import AuthenticationRoutes from './AuthenticationRoutes';
 
 const propTypes = {
-  notAuthentified: PropTypes.node,
+  notAuthenticated: PropTypes.node,
   notAuthorized: PropTypes.node,
   children: PropTypes.node,
 };
 
 const defaultProps = {
-  notAuthentified: null,
+  notAuthenticated: null,
   notAuthorized: null,
   children: PropTypes.node,
 };
 
-const OidcRoutes = ({ notAuthentified, notAuthorized, children }) => (
+const OidcRoutes = ({ notAuthenticated, notAuthorized, children }) => (
   <Switch>
     <Route
       path="/authentication"
-      component={AuthenticationRoutes(notAuthentified, notAuthorized)}
+      component={AuthenticationRoutes(notAuthenticated, notAuthorized)}
     />
     <Route render={() => children} />
   </Switch>


### PR DESCRIPTION
## A picture tells a thousand words

Hello again!

This one is an English correction. We wouldn't refer to something as "not authentified", the correct term would be "not authenticated". I've done a search and replace here to replace all instances. It all seems to work fine for me, but please do check it.

I realise this will also change one of the routes, but this is worth it as it's correct English. Hope this is ok!

## Before this PR

Routes and props that were not authenticated were referred to as "not authentified".

## After this PR

These routes and props are using the term "not authenticated".
