### PR TITLE
doc(context): fix minor typos in readme

### DIFF
--- a/packages/context/API.md
+++ b/packages/context/API.md
@@ -51,7 +51,7 @@ When the user is connected, Api Context Consummer `AuthenticationConsumer` provi
 
 - _oidcUser_ : Object for the currently authenticated user returned by oidc Client (see [oidc client Wiki](https://github.com/IdentityModel/oidc-client-js/wiki#user))
 - _login_ : Function without parameter that launch the redirect authentication
-- _logout_ : Function without function that launch te redirect logout
+- _logout_ : Function without parameter that launch the redirect logout
 - _error_ : Error if happens
 - _isLoading_ : True when the component is loading
 

--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -88,7 +88,7 @@ const propTypes = {
 };
 ```
 
-Through the UseStore you can specify a class that can be use to store the user object. This class must define :
+Through the UserStore you can specify a class that can be used to store the user object. This class must define :
 
 ```javascript
   getItem(key: string): any;
@@ -97,9 +97,9 @@ Through the UseStore you can specify a class that can be use to store the user o
   key(index: number): any;
   length?: number;
 ```
-It could also be window.localStorage or window.sessionStorage. By default, without any userStore, the sessionStorage will be use.
+It could also be window.localStorage or window.sessionStorage. By default, without any userStore, the sessionStorage will be used.
 
-See bellow a sample of configuration, you can have more information about on [oidc client github](https://github.com/IdentityModel/oidc-client-js)
+See below a sample of configuration, you can have more information about on [oidc client github](https://github.com/IdentityModel/oidc-client-js)
 
 ```javascript
 const configuration = {


### PR DESCRIPTION
Couple of minor self-explanatory wording and typo fixes for the documentation.