### PR TITLE
(docs) Improve component order

### DIFF
--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -33,17 +33,18 @@ import oidcConfiguration from './configuration';
 
 const App = () => (
   <div>
-    <Router>
-      <AuthenticationProvider configuration={oidcConfiguration} loggerLevel={oidcLog.DEBUG}>
+    <AuthenticationProvider configuration={oidcConfiguration} loggerLevel={oidcLog.DEBUG}>
+      <Router>
         <Header />
         <Routes />
-      </AuthenticationProvider>
-    </Router>
+      </Router>
+    </AuthenticationProvider>
   </div>
 );
 
 render(<App />, document.getElementById('root'));
 ```
+Note that it is important to place the `AuthenticationProvider` around the router to avoid problems with components that do not render.
 
 `AuthenticationProvider` accept the following properties :
 


### PR DESCRIPTION
Move AuthenticationProvider above Router to help people facing components that doesn't render.

Sorry for my english I try to do my best !

## Before this PR
`AuthenticationProvider` was inside the router and sometimes people was facing components that doesn't render. (like me in #422 )

## After this PR
Now `AuthenticationProvider` is around the router and people should not faces components that doesn't render.
