### PR TITLE
fix: add logout action

### DIFF
--- a/packages/context/src/oidcContext/AuthenticationContext.hooks.spec.ts
+++ b/packages/context/src/oidcContext/AuthenticationContext.hooks.spec.ts
@@ -22,6 +22,7 @@ describe('useAuthenticationContextState hook tests suite', () => {
     expect(result.current.oidcState).toEqual({
       error: '',
       isLoading: false,
+      isLoggingOut: false,
       oidcUser: null,
       userManager: { getUser: expect.any(Function) },
     });
@@ -34,6 +35,7 @@ describe('useAuthenticationContextState hook tests suite', () => {
     expect(result.current.oidcState).toEqual({
       error: 'Error occured #10298',
       isLoading: false,
+      isLoggingOut: false,
       oidcUser: null,
       userManager: { getUser: expect.any(Function) },
     });
@@ -46,6 +48,7 @@ describe('useAuthenticationContextState hook tests suite', () => {
     expect(result.current.oidcState).toEqual({
       error: '',
       isLoading: false,
+      isLoggingOut: false,
       oidcUser: { firstname: 'Jean', id_token: 'qsDQd23eDEzed' },
       userManager: { getUser: expect.any(Function) },
     });
@@ -58,6 +61,7 @@ describe('useAuthenticationContextState hook tests suite', () => {
     expect(result.current.oidcState).toEqual({
       error: '',
       isLoading: true,
+      isLoggingOut: false,
       oidcUser: null,
       userManager: { getUser: expect.any(Function) },
     });
@@ -70,6 +74,7 @@ describe('useAuthenticationContextState hook tests suite', () => {
     expect(result.current.oidcState).toEqual({
       error: '',
       isLoading: false,
+      isLoggingOut: false,
       oidcUser: { firstname: 'Jean', id_token: 'qsDQd23eDEzed' },
       userManager: { getUser: expect.any(Function) },
     });
@@ -77,6 +82,20 @@ describe('useAuthenticationContextState hook tests suite', () => {
     expect(result.current.oidcState).toEqual({
       error: '',
       isLoading: false,
+      isLoggingOut: false,
+      oidcUser: null,
+      userManager: { getUser: expect.any(Function) },
+    });
+  });
+
+  it('should change state whan call onLogout', () => {
+    // @ts-ignore
+    const { result } = renderHook(() => useAuthenticationContextState(userManagerMock));
+    act(() => result.current.onLogout());
+    expect(result.current.oidcState).toEqual({
+      error: '',
+      isLoading: false,
+      isLoggingOut: true,
       oidcUser: null,
       userManager: { getUser: expect.any(Function) },
     });

--- a/packages/context/src/oidcContext/AuthenticationContext.hooks.ts
+++ b/packages/context/src/oidcContext/AuthenticationContext.hooks.ts
@@ -8,6 +8,7 @@ export interface OidcState {
   userManager: UserManager;
   isLoading: boolean;
   error: string;
+  isLoggingOut: boolean;
 }
 
 export interface UseAuthenticationContextStateType {
@@ -15,6 +16,7 @@ export interface UseAuthenticationContextStateType {
   loadUser: Function;
   onLoading: Function;
   unloadUser: Function;
+  onLogout: Function;
   oidcState: OidcState;
 }
 
@@ -22,12 +24,14 @@ const ON_LOADING = 'ON_LOADING';
 const ON_ERROR = 'ON_ERROR';
 const ON_LOAD_USER = 'ON_LOAD_USER';
 const ON_UNLOAD_USER = 'ON_UNLOAD_USER';
+const ON_LOGOUT = 'ON_LOGOUT';
 
 type OidcAction =
   | { type: 'ON_LOADING' }
   | { type: 'ON_ERROR'; message: string }
   | { type: 'ON_LOAD_USER'; user: User | null }
-  | { type: 'ON_UNLOAD_USER' };
+  | { type: 'ON_UNLOAD_USER' }
+  | { type: 'ON_LOGOUT' };
 
 const getDefaultState = (userManagerInt: UserManager): OidcState => {
   return {
@@ -35,6 +39,7 @@ const getDefaultState = (userManagerInt: UserManager): OidcState => {
     userManager: userManagerInt,
     isLoading: false,
     error: '',
+    isLoggingOut: false,
   };
 };
 
@@ -48,15 +53,18 @@ const oidcReducer = (oidcState: OidcState, action: OidcAction): OidcState => {
       return { ...oidcState, oidcUser: action.user, isLoading: false };
     case ON_UNLOAD_USER:
       return { ...oidcState, oidcUser: null, isLoading: false };
+    case ON_LOGOUT:
+      return { ...oidcState, isLoggingOut: true };
     default:
       return oidcState;
   }
 };
 
-const onError = (dispatch: Dispatch<OidcAction>) => (message: string) => dispatch({ type: ON_ERROR, message });
-const loadUser = (dispatch: Dispatch<OidcAction>) => (user: User | null) => dispatch({ type: ON_LOAD_USER, user });
-const onLoading = (dispatch: Dispatch<OidcAction>) => () => dispatch({ type: ON_LOADING });
-const unloadUser = (dispatch: Dispatch<OidcAction>) => () => dispatch({ type: ON_UNLOAD_USER });
+const onError = (dispatch: Dispatch<OidcAction>) => (message: string) => dispatch({ type: 'ON_ERROR', message });
+const loadUser = (dispatch: Dispatch<OidcAction>) => (user: User | null) => dispatch({ type: 'ON_LOAD_USER', user });
+const onLoading = (dispatch: Dispatch<OidcAction>) => () => dispatch({ type: 'ON_LOADING' });
+const unloadUser = (dispatch: Dispatch<OidcAction>) => () => dispatch({ type: 'ON_UNLOAD_USER' });
+const onLogout = (dispatch: Dispatch<OidcAction>) => () => dispatch({ type: 'ON_LOGOUT' });
 
 export const useAuthenticationContextState = (userManagerInt: UserManager): UseAuthenticationContextStateType => {
   const defaultState = getDefaultState(userManagerInt);
@@ -67,6 +75,7 @@ export const useAuthenticationContextState = (userManagerInt: UserManager): UseA
     loadUser: useCallback(user => loadUser(dispatch)(user), []),
     onLoading: useCallback(() => onLoading(dispatch)(), []),
     unloadUser: useCallback(() => unloadUser(dispatch)(), []),
+    onLogout: useCallback(() => onLogout(dispatch)(), []),
     oidcState,
   };
 };

--- a/packages/context/src/oidcContext/AuthenticationContext.provider.tsx
+++ b/packages/context/src/oidcContext/AuthenticationContext.provider.tsx
@@ -101,8 +101,8 @@ export const AuthenticationProviderInt = ({
   logoutUserInt,
 }: AuthenticationProviderIntProps) => {
   const userManager = authenticationServiceInt(configuration, UserStore);
-  const { oidcState, loadUser, onError, onLoading, unloadUser } = useAuthenticationContextState(userManager);
-  const oidcFunctions = { loadUser, onError, onLoading, unloadUser };
+  const { oidcState, loadUser, onError, onLoading, unloadUser, onLogout } = useAuthenticationContextState(userManager);
+  const oidcFunctions = { loadUser, onError, onLoading, unloadUser, onLogout };
   const { addOidcEvents, removeOidcEvents } = useOidcEvents(oidcLogInt, userManager, oidcFunctions);
 
   useEffect(() => {
@@ -134,12 +134,13 @@ export const AuthenticationProviderInt = ({
 
   const logoutCallback = useCallback(async () => {
     try {
+      onLogout();
       await logoutUserInt(userManager);
       oidcLogInt.info('Logout successfull');
     } catch (error) {
       onError(error.message);
     }
-  }, [logoutUserInt, oidcLogInt, onError, userManager]);
+  }, [logoutUserInt, oidcLogInt, onError, onLogout, userManager]);
   return (
     <AuthenticationContext.Provider
       value={{

--- a/packages/context/src/oidcContext/AuthenticationContext.tsx
+++ b/packages/context/src/oidcContext/AuthenticationContext.tsx
@@ -9,6 +9,7 @@ export type oidcContext = {
   events: UserManagerEvents;
   authenticating: ComponentType;
   isLoading: boolean;
+  isLoggingOut: boolean;
   userManager: UserManager;
   error: string;
 };

--- a/packages/context/src/reactServices/OidcSecure.tsx
+++ b/packages/context/src/reactServices/OidcSecure.tsx
@@ -33,17 +33,17 @@ export const useOidcSecure = (
   isRequireAuthenticationInternal: typeof isRequireAuthentication,
   WrappedComponent: ComponentType
 ): ComponentType => {
-  const { isEnabled, oidcUser, authenticating } = useContext(AuthenticationContext);
+  const { isEnabled, oidcUser, authenticating, isLoggingOut } = useContext(AuthenticationContext);
   useEffect(() => {
     oidcLogInternal.info('Protection : ', isEnabled);
-    if (isEnabled) {
+    if (isEnabled && !isLoggingOut) {
       oidcLogInternal.info('Protected component mounted');
       authenticateUserInternal(userManager, location, history)();
     }
     return () => {
       oidcLogInternal.info('Protected component unmounted');
     };
-  }, [isEnabled, authenticateUserInternal, userManager, oidcLogInternal, location, history]);
+  }, [isEnabled, authenticateUserInternal, userManager, oidcLogInternal, location, history, isLoggingOut]);
   const requiredAuth = useMemo(() => isRequireAuthenticationInternal(oidcUser, false) && isEnabled, [
     isEnabled,
     isRequireAuthenticationInternal,


### PR DESCRIPTION
## A picture tells a thousand words

When performing a disconnection, an authentication was restarted

## Before this PR
An authentication was launched during the disconnection

## After this PR
Additional action allowing a dispatch which launches the disconnection action properly
