### PR TITLE
feat(react-oidc-redux): Adding Redux Authenticating component

### DIFF
--- a/examples/redux/src/App.js
+++ b/examples/redux/src/App.js
@@ -92,7 +92,7 @@ const CustomAuthenticatingComponent = () => (
 );
 
 const ProtectedChild = () => (
-  <OidcSecure isEnabled={configuration.isEnabled} authenticatingComponent={CustomAuthenticatingComponent}>
+  <OidcSecure isEnabled={configuration.isEnabled} authenticating={CustomAuthenticatingComponent}>
     <div className="App">
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />

--- a/examples/redux/src/App.js
+++ b/examples/redux/src/App.js
@@ -1,19 +1,19 @@
-import React, { Component } from "react";
-import logo from "./logo.svg";
-import "./App.css";
-import { Route, Switch, Link } from "react-router-dom";
-import { OidcSecure, oidcSecure } from "@axa-fr/react-oidc-redux";
-import { withAuthentication } from "@axa-fr/react-oidc-redux-fetch";
-import User from "./User";
-import configuration from "./configuration";
-import { compose, withProps } from "recompose";
+import React, { Component } from 'react';
+import logo from './logo.svg';
+import './App.css';
+import { Route, Switch, Link } from 'react-router-dom';
+import { OidcSecure, oidcSecure } from '@axa-fr/react-oidc-redux';
+import { withAuthentication } from '@axa-fr/react-oidc-redux-fetch';
+import User from './User';
+import configuration from './configuration';
+import { compose, withProps } from 'recompose';
 
 const fetch = status => (url, options) => {
   return new Promise(resolve => {
     setTimeout(
       () =>
         resolve({
-          status
+          status,
         }),
       350
     );
@@ -26,10 +26,10 @@ const enhance401 = compose(
     handleClick: e => {
       e.preventDefault();
       props
-        .fetch("http://www.demo.url")
-        .then(() => alert("fetch end"))
+        .fetch('http://www.demo.url')
+        .then(() => alert('fetch end'))
         .catch(e => alert(e));
-    }
+    },
   }))
 );
 
@@ -47,10 +47,10 @@ const enhance403 = compose(
     handleClick: e => {
       e.preventDefault();
       props
-        .fetch("http://www.demo.url")
-        .then(() => alert("fetch end"))
+        .fetch('http://www.demo.url')
+        .then(() => alert('fetch end'))
         .catch(e => alert(e));
-    }
+    },
   }))
 );
 
@@ -70,15 +70,29 @@ const Home = () => (
     </header>
     <Link to="/protected1">protected1</Link>
     <span> - </span>
-    <Link to="/protected2">protected2</Link>
+    <Link to="/protected2">
+      protected2{' '}
+      <small>
+        <i>(with custom Authenticating Component)</i>
+      </small>
+    </Link>
     <p>Demo access_token is valid during 30 seconds</p>
     <Button403Enhance />
     <Button401Enhance />
   </div>
 );
 
+const CustomAuthenticatingComponent = () => (
+  <div className="App">
+    <header className="App-header">
+      <h1 className="App-title">Authenticating</h1>
+      <i>rendered with a custom Component</i>
+    </header>
+  </div>
+);
+
 const ProtectedChild = () => (
-  <OidcSecure isEnabled={configuration.isEnabled}>
+  <OidcSecure isEnabled={configuration.isEnabled} authenticatingComponent={CustomAuthenticatingComponent}>
     <div className="App">
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />

--- a/packages/redux/README.md
+++ b/packages/redux/README.md
@@ -162,9 +162,9 @@ You can use `OidcSecure` wrapper component or `oidcSecure` HOC function.
    */
   isEnabled?: boolean;
   /**
-   * Overriding Auhthenticating Component
+   * Custom Authenticating Component
    */
-  authenticatingComponent?: ComponentType;
+  authenticating?: ComponentType;
 };
 ```
 

--- a/packages/redux/README.md
+++ b/packages/redux/README.md
@@ -109,6 +109,7 @@ Through the UseStore you can specify a class that can be use to store the user o
   key(index: number): any;
   length?: number;
 ```
+
 It could also be window.localStorage or window.sessionStorage. By default, without any userStore, the sessionStorage will be use.
 
 See bellow a sample of configuration, you can have more information about on [oidc client github](https://github.com/IdentityModel/oidc-client-js)
@@ -150,6 +151,25 @@ export default combineReducers({
 
 ### How to secure a component (App.js)
 
+You can use `OidcSecure` wrapper component or `oidcSecure` HOC function.
+
+`OidcSecure` accepte the following props:
+
+```javascript
+{
+  /**
+   * Enable secure authentication for component
+   */
+  isEnabled?: boolean;
+  /**
+   * Overriding Auhthenticating Component
+   */
+  authenticatingComponent?: ComponentType;
+};
+```
+
+Example:
+
 ```javascript
 import React, { Component } from 'react';
 import logo from './logo.svg';
@@ -158,8 +178,10 @@ import { Route, Switch } from 'react-router-dom';
 import { OidcSecure, oidcSecure } from '@axa-fr/react-oidc-redux';
 import User from './User';
 
+const CustomAuthenticatingComponent = () => <div>Authenticating ...</div>;
+
 const ProtectedChild = () => (
-  <OidcSecure>
+  <OidcSecure authenticating={CustomAuthenticatingComponent}>
     <div className="App">
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />

--- a/packages/redux/src/OidcSecure.tsx
+++ b/packages/redux/src/OidcSecure.tsx
@@ -1,8 +1,8 @@
-import React, { ComponentType, FC, PropsWithChildren, useEffect } from 'react';
+import React, { ComponentType, FC, PropsWithChildren, useEffect, useMemo } from 'react';
 
 import PropTypes from 'prop-types';
 import {
-  Authenticating,
+  Authenticating as DefaultAuthenticatingComponent,
   withRouter,
   getUserManager,
   isRequireAuthentication,
@@ -17,14 +17,10 @@ type AuthenticationLiveCycleProps = PropsWithChildren<{
   location: Location;
   history: ReactOidcHistory;
   oidc: UserState;
+  authenticatingComponent: ComponentType;
 }>;
 
-const AuthenticationLiveCycle: FC<AuthenticationLiveCycleProps> = ({
-  location,
-  oidc,
-  children,
-  history,
-}) => {
+const AuthenticationLiveCycle: FC<AuthenticationLiveCycleProps> = ({ location, oidc, children, history, authenticatingComponent }) => {
   const { isLoadingUser, user } = oidc;
   const isShouldAuthenticate = !isLoadingUser && isRequireAuthentication(user);
   const isLoading = isLoadingUser || isShouldAuthenticate;
@@ -35,7 +31,9 @@ const AuthenticationLiveCycle: FC<AuthenticationLiveCycleProps> = ({
     }
   }, [isShouldAuthenticate, location, user]);
 
-  return isLoading ? <Authenticating /> : <>{children}</>;
+  const AuthenticatingComponent: ComponentType = useMemo(() => authenticatingComponent || DefaultAuthenticatingComponent, []);
+
+  return isLoading ? <AuthenticatingComponent /> : <>{children}</>;
 };
 
 const mapStateToProps = (state: any) => ({
@@ -71,12 +69,13 @@ const defaultPropsOidcSecure = {
 
 type OidcSecureProps = PropsWithChildren<{
   isEnabled?: boolean;
+  authenticatingComponent: ComponentType;
 }>;
 
 const OidcSecure: FC<OidcSecureProps> = props => {
-  const { isEnabled, children } = props;
+  const { isEnabled, children, ...configProps } = props;
   if (isEnabled) {
-    return <Secure>{children}</Secure>;
+    return <Secure {...configProps}>{children}</Secure>;
   }
   return <>{children}</>;
 };

--- a/packages/redux/src/OidcSecure.tsx
+++ b/packages/redux/src/OidcSecure.tsx
@@ -68,8 +68,14 @@ const defaultPropsOidcSecure = {
 };
 
 type OidcSecureProps = PropsWithChildren<{
+  /**
+   * Enable secure authentication for component
+   */
   isEnabled?: boolean;
-  authenticatingComponent: ComponentType;
+  /**
+   * Overriding Auhthenticating Component
+   */
+  authenticatingComponent?: ComponentType;
 }>;
 
 const OidcSecure: FC<OidcSecureProps> = props => {

--- a/packages/redux/src/OidcSecure.tsx
+++ b/packages/redux/src/OidcSecure.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, FC, PropsWithChildren, useEffect, useMemo } from 'react';
+import React, { ComponentType, FC, PropsWithChildren, useEffect } from 'react';
 
 import PropTypes from 'prop-types';
 import {
@@ -31,7 +31,7 @@ const AuthenticationLiveCycle: FC<AuthenticationLiveCycleProps> = ({ location, o
     }
   }, [isShouldAuthenticate, location, user]);
 
-  const AuthenticatingComponent: ComponentType = useMemo(() => authenticatingComponent || DefaultAuthenticatingComponent, []);
+  const AuthenticatingComponent: ComponentType = authenticatingComponent || DefaultAuthenticatingComponent;
 
   return isLoading ? <AuthenticatingComponent /> : <>{children}</>;
 };

--- a/packages/redux/src/OidcSecure.tsx
+++ b/packages/redux/src/OidcSecure.tsx
@@ -17,10 +17,10 @@ type AuthenticationLiveCycleProps = PropsWithChildren<{
   location: Location;
   history: ReactOidcHistory;
   oidc: UserState;
-  authenticatingComponent: ComponentType;
+  authenticating: ComponentType;
 }>;
 
-const AuthenticationLiveCycle: FC<AuthenticationLiveCycleProps> = ({ location, oidc, children, history, authenticatingComponent }) => {
+const AuthenticationLiveCycle: FC<AuthenticationLiveCycleProps> = ({ location, oidc, children, history, authenticating }) => {
   const { isLoadingUser, user } = oidc;
   const isShouldAuthenticate = !isLoadingUser && isRequireAuthentication(user);
   const isLoading = isLoadingUser || isShouldAuthenticate;
@@ -31,7 +31,7 @@ const AuthenticationLiveCycle: FC<AuthenticationLiveCycleProps> = ({ location, o
     }
   }, [isShouldAuthenticate, location, user]);
 
-  const AuthenticatingComponent: ComponentType = authenticatingComponent || DefaultAuthenticatingComponent;
+  const AuthenticatingComponent: ComponentType = authenticating || DefaultAuthenticatingComponent;
 
   return isLoading ? <AuthenticatingComponent /> : <>{children}</>;
 };
@@ -73,9 +73,9 @@ type OidcSecureProps = PropsWithChildren<{
    */
   isEnabled?: boolean;
   /**
-   * Overriding Auhthenticating Component
+   * Custom Authenticating Component
    */
-  authenticatingComponent?: ComponentType;
+  authenticating?: ComponentType;
 }>;
 
 const OidcSecure: FC<OidcSecureProps> = props => {


### PR DESCRIPTION
## [Issue [452](https://github.com/AxaGuilDEv/react-oidc/issues/452)] Add possibility to customize Authenticating component for oidc-redux as in oidc-context 

## OidcSecure use systematically the default component

## And now we can customize it 👍 

> Please note, some unrelated changes are due to project Prettier config that input singleQuote and trailing comma