### PR TITLE
fix(context): made type for AuthenticationProviderProps partial

### DIFF
--- a/packages/context/src/oidcContext/AuthenticationContext.provider.tsx
+++ b/packages/context/src/oidcContext/AuthenticationContext.provider.tsx
@@ -175,7 +175,7 @@ type AuthenticationProviderProps = Omit<AuthenticationProviderIntProps,
   | 'logoutUserInt'
 >
 
-const AuthenticationProvider: ComponentType<AuthenticationProviderProps> = withRouter(
+const AuthenticationProvider: ComponentType<Partial<AuthenticationProviderProps>> = withRouter(
   withServices(AuthenticationProviderInt, {
     CallbackInt: Callback,
     authenticationServiceInt: authenticationService,


### PR DESCRIPTION
## Before this PR
Typescript throws errors when when a partial configuration is served to the AuthenticationProvider.

## After this PR
This should fix #472
Suggested by @ghostd in https://github.com/AxaGuilDEv/react-oidc/pull/457#issuecomment-644894640_