### PR TITLE
Delete logger debug for overriden configuration

### DIFF
--- a/examples/context/src/Pages/SimpleComponent/index.js
+++ b/examples/context/src/Pages/SimpleComponent/index.js
@@ -4,7 +4,7 @@ const SimpleComponent = ({ type }) => {
   const [state, setState] = React.useState('init');
   const handleChange = React.useCallback(e => {
     setState(e.target.value);
-  });
+  }, [setState]);
   return (
     <>
       <h1>Simple Component</h1>

--- a/packages/core/src/services/authenticationService.ts
+++ b/packages/core/src/services/authenticationService.ts
@@ -28,7 +28,6 @@ export const authenticationServiceInternal = (
   if (UserStore) {
     overriddenConfiguration.userStore = new WebStorageStateStoreInt({ store: new UserStore() });
   }
-  oidcLog.debug('overriddenConfiguration', overriddenConfiguration);
   userManager = new UserManager(overriddenConfiguration);
   return userManager;
 };

--- a/packages/core/src/services/loggerService.ts
+++ b/packages/core/src/services/loggerService.ts
@@ -1,6 +1,6 @@
 import { Log, Logger } from 'oidc-client';
 
-let oidcLogLevel: number = Log.DEBUG;
+let oidcLogLevel: number = Log.WARN;
 
 export type ReactOidcLogger = Logger;
 


### PR DESCRIPTION
On each call to Oauth2 server into a browser, we have a debug console entry that contains all configuration.

But for security it's better to not expose debug console entry into production (pentests result recommendation).

First I try to change into main component **AuthenticationProvider** but it doesn't change anythings. This is cause by call order of logger init & authentication.

So my PR remove this debug console entry. We can discuss to find a better solution.