### PR TITLE
fix(core): keep location.hash in the url used to redirect after login

### DIFF
--- a/packages/core/src/services/oidcServices.spec.ts
+++ b/packages/core/src/services/oidcServices.spec.ts
@@ -1,5 +1,5 @@
-import { authenticateUser, logoutUser, signinSilent } from './oidcServices';
 import { User, UserManager } from 'oidc-client';
+import { authenticateUser, logoutUser, signinSilent } from './oidcServices';
 
 jest.mock('./loggerService');
 
@@ -48,6 +48,19 @@ describe('authenticate testing', () => {
     });
   });
 
+  it('authenticateUser should call signin redirect with force to true with url= path + search + hash', async () => {
+    const localLocationMock = ({
+      pathname: '/pathname',
+      search: '?toto=tutu',
+      hash: '#titi',
+    } as unknown) as Location;
+    await authenticateUser(userManagerMock, localLocationMock)(true);
+    expect(userManagerMock.getUser).toHaveBeenCalled();
+    expect(userManagerMock.signinRedirect).toHaveBeenCalledWith({
+      data: { url: '/pathname?toto=tutu#titi' },
+    });
+  });
+
   it('authenticateUser should call signin redirect with force to true with url = callbackUrl', async () => {
     await authenticateUser(userManagerMock, locationMock)(true, '/injectedpath');
     expect(userManagerMock.getUser).toHaveBeenCalled();
@@ -65,9 +78,7 @@ describe('authenticate testing', () => {
     expect(userManagerMockLocal.signinSilent).toHaveBeenCalled();
   });
 
-  it(
-    'authenticateUser should call signinsilent that fail and should call first signinRedirect and then should call history.push',
-    async () => {
+  it('authenticateUser should call signinsilent that fail and should call first signinRedirect and then should call history.push', async () => {
     const sleep = (ms: number) => {
       return new Promise(resolve => setTimeout(resolve, ms));
     };

--- a/packages/core/src/services/oidcServices.spec.ts
+++ b/packages/core/src/services/oidcServices.spec.ts
@@ -1,5 +1,5 @@
-import { User, UserManager } from 'oidc-client';
 import { authenticateUser, logoutUser, signinSilent } from './oidcServices';
+import { User, UserManager } from 'oidc-client';
 
 jest.mock('./loggerService');
 
@@ -78,7 +78,9 @@ describe('authenticate testing', () => {
     expect(userManagerMockLocal.signinSilent).toHaveBeenCalled();
   });
 
-  it('authenticateUser should call signinsilent that fail and should call first signinRedirect and then should call history.push', async () => {
+  it(
+    'authenticateUser should call signinsilent that fail and should call first signinRedirect and then should call history.push',
+    async () => {
     const sleep = (ms: number) => {
       return new Promise(resolve => setTimeout(resolve, ms));
     };

--- a/packages/core/src/services/oidcServices.ts
+++ b/packages/core/src/services/oidcServices.ts
@@ -24,7 +24,7 @@ export const authenticateUser = (
     return;
   }
   numberAuthentication++;
-  const url = callbackPath || location.pathname + (location.search || '');
+  const url = callbackPath || location.pathname + (location.search || '') + (location.hash || '');
 
   if (isRequireSignin(oidcUser, isForce)) {
     oidcLog.info('authenticate user...');


### PR DESCRIPTION
## A picture tells a thousand words
![image](https://user-images.githubusercontent.com/70629078/91965626-09087e80-ed11-11ea-96d1-41bbef323ef8.png)
![image](https://user-images.githubusercontent.com/70629078/91965493-d65e8600-ed10-11ea-89f6-ae090f643754.png)

## Before this PR
When accessing a protected route with a hash part in the URL, the hash part is lost in the URL where we are redirected.
For example, when accessing http://mywebsite.com/#/tasks/tasks-list, we are redirected to http://mywebsite.com/ after login.
This is especially an issue when we use a "HashRouter" and all the routing is managed thanks to the hash part of the URL.

## After this PR
The hash part is kept in the URL that is sent to the identity server in the state, and we are redirected successully to the initial route. For example, when accessing http://mywebsite.com/#/tasks/tasks-list, we are redirected to http://mywebsite.com/#/tasks/tasks-list after login.


