### PR TITLE
feat: unload userManager when unmount oidc provider

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,6 @@ To get started with the repository:
 git clone https://github.com/AxaGuilDEv/react-oidc.git
 cd react-oidc
 npm install
-npm run bootstrap
 ```
 
 ## Commands

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ steps:
         sonar.cfamily.build-wrapper-output.bypass=true
     condition: and(succeeded(), eq(variables['System.PullRequest.IsFork'], 'False'))
 
-  - script: npm install && npm run bootstrap
+  - script: npm install
     displayName: 'npm install and bootstrap'
 
   - script: npm test -- --coverage

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "url": "https://github.com/AxaGuilDEv/react-oidc.git"
   },
   "scripts": {
-    "bootstrap": "lerna bootstrap",
     "publish": "lerna publish",
+    "postinstall": "lerna bootstrap",
     "start": "npm run example:context",
     "clean": "lerna clean",
     "example:redux": "npm -C ./examples/redux run start",

--- a/packages/context/src/oidcContext/AuthenticationContext.provider.spec.tsx
+++ b/packages/context/src/oidcContext/AuthenticationContext.provider.spec.tsx
@@ -86,6 +86,7 @@ const propsMocks = {
   },
   authenticateUserInt: jest.fn(() => () => {}),
   logoutUserInt: jest.fn(),
+  setUserManagerInt : jest.fn()
 };
 
 const getWrapper = props => ({ children }) => <AuthenticationProviderInt {...props}>{children}</AuthenticationProviderInt>;
@@ -143,6 +144,7 @@ describe('AuthContext tests suite', () => {
     expect(userManagerMock.events.removeUserUnloaded).not.toBeCalled();
     expect(userManagerMock.events.removeUserSignedOut).not.toBeCalled();
     expect(userManagerMock.events.removeAccessTokenExpired).not.toBeCalled();
+    expect(propsMocks.setUserManagerInt).not.toBeCalled();
 
     unmount();
 
@@ -151,6 +153,7 @@ describe('AuthContext tests suite', () => {
     expect(userManagerMock.events.removeUserUnloaded).toBeCalled();
     expect(userManagerMock.events.removeUserSignedOut).toBeCalled();
     expect(userManagerMock.events.removeAccessTokenExpired).toBeCalled();
+    expect(propsMocks.setUserManagerInt).toBeCalledWith(null);
   });
 
   it('should change state and call when click on login', async () => {

--- a/packages/context/src/oidcContext/AuthenticationContext.provider.tsx
+++ b/packages/context/src/oidcContext/AuthenticationContext.provider.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useCallback, ComponentType, PropsWithChildren } from 'react';
 import PropTypes from 'prop-types';
-import { User, Logger, UserManagerSettings, UserManagerEvents } from 'oidc-client';
+import { User, Logger, UserManagerSettings } from 'oidc-client';
 import {
   withRouter,
   authenticationService,
@@ -13,6 +13,7 @@ import {
   oidcLog,
   authenticateUser,
   logoutUser,
+  setUserManager,
 } from '@axa-fr/react-oidc-core';
 
 import { Callback } from '../Callback';
@@ -42,6 +43,7 @@ type AuthenticationProviderIntProps = PropsWithChildren<{
   authenticateUserInt: typeof authenticateUser;
   logoutUserInt: typeof logoutUser;
   customEvents: CustomEvents;
+  setUserManagerInt: typeof setUserManager;
 }>;
 
 const propTypes = {
@@ -111,6 +113,7 @@ export const AuthenticationProviderInt = ({
   oidcLogInt,
   authenticateUserInt,
   logoutUserInt,
+  setUserManagerInt,
 }: AuthenticationProviderIntProps) => {
   const userManager = authenticationServiceInt(configuration, UserStore);
   const { oidcState, loadUser, onError, onLoading, unloadUser, onLogout } = useAuthenticationContextState(userManager);
@@ -130,8 +133,9 @@ export const AuthenticationProviderInt = ({
     return () => {
       removeOidcEvents();
       mount = false;
+      setUserManagerInt(null);
     };
-  }, [addOidcEvents, loadUser, logger, loggerLevel, onLoading, removeOidcEvents, setLoggerInt, userManager, customEvents]);
+  }, [addOidcEvents, loadUser, logger, loggerLevel, onLoading, removeOidcEvents, setLoggerInt, setUserManagerInt, userManager]);
 
   const CallbackComponent = React.useMemo(
     () => (callbackComponentOverride ? withComponentOverrideProps(CallbackInt, callbackComponentOverride) : CallbackInt),
@@ -191,6 +195,7 @@ const AuthenticationProvider: ComponentType<Partial<AuthenticationProviderProps>
     oidcLogInt: oidcLog,
     authenticateUserInt: authenticateUser,
     logoutUserInt: logoutUser,
+    setUserManagerInt: setUserManager,
   })
 );
 // @ts-ignore

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,4 +13,5 @@ export {
   oidcLog,
   InMemoryWebStorage,
   UserStoreType,
+  setUserManager,
 } from './services';


### PR DESCRIPTION
Used by [Tokgen](https://github.com/youf-olivier/tokgen) We have ann issue when unmounting the provider. The userManager persists.

We have to set the userManager to null when the provider is unmounted to be able te configure it with another configuration set

I also simplified the install script.