### PR TITLE
ci: add dependabot config file and change prefix to `build(npm)`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: 'npm'
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: '/'
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: 'daily'
+    commit-message:
+      prefix: 'build(npm): '


### PR DESCRIPTION
chore is deprecated, so I am trying to change the prefix to build