### PR TITLE
Allowing for more complex route paths for built in authentication end…

### DIFF
--- a/packages/core/src/routes/OidcRoutes.tsx
+++ b/packages/core/src/routes/OidcRoutes.tsx
@@ -2,13 +2,14 @@ import React, { ComponentType, FC, PropsWithChildren, useEffect, useState } from
 import PropTypes from 'prop-types';
 import { UserManagerSettings } from 'oidc-client';
 import { NotAuthenticated, NotAuthorized, SessionLost } from '../default-component';
-import { getPath } from './route-utils';
+import { getPath, getAuthenticationRoutePath } from './route-utils';
 import { SilentCallback } from '../callbacks';
 
 const propTypes = {
   notAuthenticated: PropTypes.elementType,
   notAuthorized: PropTypes.elementType,
   callbackComponent: PropTypes.elementType.isRequired,
+  sessionLost: PropTypes.elementType,
   configuration: PropTypes.shape({
     redirect_uri: PropTypes.string.isRequired,
     silent_redirect_uri: PropTypes.string.isRequired,
@@ -19,6 +20,7 @@ const propTypes = {
 const defaultProps: Partial<OidcRoutesProps> = {
   notAuthenticated: null,
   notAuthorized: null,
+  sessionLost: null,
 };
 
 type OidcRoutesProps = {
@@ -52,20 +54,17 @@ const OidcRoutes: FC<PropsWithChildren<OidcRoutesProps>> = ({
   const silentCallbackPath = getPath(configuration.silent_redirect_uri);
   const callbackPath = getPath(configuration.redirect_uri);
 
-  switch (path) {
-    case callbackPath:
-      return <CallbackComponent />;
-    case silentCallbackPath:
-      return <SilentCallback />;
-    case '/authentication/not-authenticated':
-      return <NotAuthenticatedComponent />;
-    case '/authentication/not-authorized':
-      return <NotAuthorizedComponent />;
-    case '/authentication/session-lost':
-      return <SessionLostComponent />;
-    default:
-      return <>{children}</>;
+  if (path === callbackPath) return <CallbackComponent />;
+  if (path === silentCallbackPath) return <SilentCallback />;
+
+  const authenticationRoute = getAuthenticationRoutePath(path);
+  if (authenticationRoute) {
+    if (authenticationRoute === 'authentication/not-authenticated') return <NotAuthenticatedComponent />;
+    if (authenticationRoute === 'authentication/not-authorized') return <NotAuthorizedComponent />;
+    if (authenticationRoute === 'authentication/session-lost') return <SessionLostComponent />;
   }
+
+  return <>{children}</>;
 };
 
 // @ts-ignore

--- a/packages/core/src/routes/route-utils.ts
+++ b/packages/core/src/routes/route-utils.ts
@@ -39,4 +39,4 @@ export const getAuthenticationRoutePath = (hrefPathName: string) => {
   const basePath = segments.pop();
 
   return basePath && authenticationRoute ? `${basePath}/${authenticationRoute}` : undefined;
-}
+};

--- a/packages/core/src/routes/route-utils.ts
+++ b/packages/core/src/routes/route-utils.ts
@@ -32,3 +32,11 @@ export const getPath = (href: string) => {
 
   return path;
 };
+
+export const getAuthenticationRoutePath = (hrefPathName: string) => {
+  const segments = hrefPathName.split('/');
+  const authenticationRoute = segments.pop() || segments.pop();
+  const basePath = segments.pop();
+
+  return basePath && authenticationRoute ? `${basePath}/${authenticationRoute}` : undefined;
+}


### PR DESCRIPTION
…points

## A picture tells a thousand words
Example return values from new function:

![image](https://user-images.githubusercontent.com/4487160/109585842-754a1c00-7ac1-11eb-9604-b8f14c515fe6.png)

## Before this PR
Before this pr the path of my app, `https://myhost/someapp` would not work with the built in authentication routes

## After this PR
This path, `https://myhost/someapp` will work while maintaining original functionality

Non breaking change that helps make the route logic more accommodating. Let me know if I could make this cleaner... Not sure how fast you all can merge and push if it looks good, coming in on a deadline but would prefer to continue to use this npm from the public registries.

Thanks guys!