### PR TITLE
fix(redux): create usermanager before rendering + some refacto

### DIFF
--- a/examples/redux/src/App.js
+++ b/examples/redux/src/App.js
@@ -119,9 +119,9 @@ class App extends Component {
   render() {
     return (
       <Switch>
+        <Route exact path="/" component={Home} />
         <Route path="/protected1" component={oidcSecure(NotProtectedChild)} />
         <Route path="/protected2" component={ProtectedChild} />
-        <Route path="/" component={Home} />
       </Switch>
     );
   }

--- a/examples/redux/src/configuration.js
+++ b/examples/redux/src/configuration.js
@@ -14,7 +14,8 @@ const configuration = {
         automaticSilentRenew: true,
         loadUserInfo: true,
         checkSessionInterval: 60,
-      }
+        monitorSession: false,
+      },
     },
     {
       origin: 'http://127.0.0.1:3000',
@@ -28,9 +29,10 @@ const configuration = {
         silent_redirect_uri: 'http://127.0.0.1:3000/authentication/silent_callback',
         automaticSilentRenew: true,
         loadUserInfo: true,
-      }
-    }
-  ]
+        monitorSession: false,
+      },
+    },
+  ],
 };
 
 export default configuration;

--- a/examples/redux/src/index.js
+++ b/examples/redux/src/index.js
@@ -18,26 +18,24 @@ const isEnabled = configuration.isEnabled;
 if (configuration.configurations.length <= 0) {
   throw new Error(`No configuration found`);
 }
-const authenticationConfig = origin
-  ? configuration.configurations.find(m => m.origin === origin)
-  : configuration.configurations[0];
+const authenticationConfig = origin ? configuration.configurations.find(m => m.origin === origin) : configuration.configurations[0];
 if (!authenticationConfig) {
   throw new Error(`Configuration not found for origin ${origin}`);
 }
 
 const Start = (
   <Provider store={store}>
-    <Router>
-      <Oidc
-        store={store}
-        configuration={authenticationConfig.config}
-        isEnabled={isEnabled}
-        callbackComponentOverride={ComponentOverride}
-        UserStore={InMemoryWebStorage}
-      >
+    <Oidc
+      store={store}
+      configuration={authenticationConfig.config}
+      isEnabled={isEnabled}
+      callbackComponentOverride={ComponentOverride}
+      UserStore={InMemoryWebStorage}
+    >
+      <Router>
         <App />
-      </Oidc>
-    </Router>
+      </Router>
+    </Oidc>
   </Provider>
 );
 

--- a/packages/redux/README.md
+++ b/packages/redux/README.md
@@ -46,6 +46,7 @@ const configuration = {
     silent_redirect_uri: 'http://localhost:3000/authentication/silent_callback',
     automaticSilentRenew: true,
     loadUserInfo: true,
+    monitorSession: false, // set to true by default. this causes a signout after few seconds in chrome browser
   },
 };
 
@@ -53,11 +54,11 @@ const isEnabled = configuration.origin === document.location.origin;
 
 const Start = (
   <Provider store={store}>
-    <BrowserRouter>
-      <Oidc store={store} configuration={configuration.config} isEnabled={isEnabled}>
+    <Oidc store={store} configuration={configuration.config} isEnabled={isEnabled}>
+      <BrowserRouter>
         <App />
-      </Oidc>
-    </BrowserRouter>
+      </BrowserRouter>
+    </Oidc>
   </Provider>
 );
 

--- a/packages/redux/src/Oidc.spec.tsx
+++ b/packages/redux/src/Oidc.spec.tsx
@@ -1,6 +1,6 @@
 // Link.react.test.js
-import React from 'react';
 import { render } from '@testing-library/react';
+import React from 'react';
 import { OidcBaseInternal } from './Oidc';
 
 jest.mock('redux-oidc', () => ({
@@ -8,7 +8,6 @@ jest.mock('redux-oidc', () => ({
 }));
 
 describe('redux.Oidc', () => {
-  const loadUserMock = jest.fn();
   const authenticationServiceMock = jest.fn(() => 'userManager');
   const noopMock = () => {};
 
@@ -30,10 +29,8 @@ describe('redux.Oidc', () => {
     };
     const { asFragment } = render(
       <OidcBaseInternal
-        isEnabled={false}
         store={{ store: 'storeMock' }}
         configuration={configuration}
-        loadUserInternal={loadUserMock}
         authenticationServiceInternal={authenticationServiceMock}
         UserStore={noopMock}
       >
@@ -42,49 +39,6 @@ describe('redux.Oidc', () => {
     );
 
     expect(asFragment()).toMatchSnapshot();
-    expect(authenticationServiceMock).not.toHaveBeenCalled();
-    expect(loadUserMock).not.toHaveBeenCalled();
-  });
-
-  it('Render <OidcBaseInternal/> correctly when is enabled', () => {
-    const configuration = {
-      client_id: 'CSk26fuOE2NjQr17oCI1bKzBch9eUzF0',
-      redirect_uri: 'http://localhost:3000/authentication/callback',
-      response_type: 'id_token token',
-      scope: 'openid profile email',
-      authority: 'https://samplesreact.eu.auth0.com',
-      silent_redirect_uri: 'http://localhost:3000/authentication/silent_callback',
-      automaticSilentRenew: true,
-      loadUserInfo: true,
-      triggerAuthFlow: true,
-    };
-    const { asFragment } = render(
-      <OidcBaseInternal
-        isEnabled
-        store={{ store: 'storeMock' }}
-        configuration={configuration}
-        loadUserInternal={loadUserMock}
-        authenticationServiceInternal={authenticationServiceMock}
-        UserStore={noopMock}
-      >
-        <p>isEnabled</p>
-      </OidcBaseInternal>
-    );
-    expect(asFragment()).toMatchSnapshot();
-    expect(authenticationServiceMock).toHaveBeenCalledWith(
-      {
-        authority: 'https://samplesreact.eu.auth0.com',
-        automaticSilentRenew: true,
-        client_id: 'CSk26fuOE2NjQr17oCI1bKzBch9eUzF0',
-        loadUserInfo: true,
-        redirect_uri: 'http://localhost:3000/authentication/callback',
-        response_type: 'id_token token',
-        scope: 'openid profile email',
-        silent_redirect_uri: 'http://localhost:3000/authentication/silent_callback',
-        triggerAuthFlow: true,
-      },
-      noopMock
-    );
-    expect(loadUserMock).toHaveBeenCalledWith({ store: 'storeMock' }, 'userManager');
+    expect(authenticationServiceMock).toHaveBeenCalled();
   });
 });

--- a/packages/redux/src/OidcSecure.tsx
+++ b/packages/redux/src/OidcSecure.tsx
@@ -21,32 +21,25 @@ type AuthenticationLiveCycleProps = PropsWithChildren<{
 }>;
 
 const AuthenticationLiveCycle: FC<AuthenticationLiveCycleProps> = ({ location, oidc, children, history, authenticating }) => {
-  const { isLoadingUser, user } = oidc;
-  const isShouldAuthenticate = !isLoadingUser && isRequireAuthentication(user);
-  const isLoading = isLoadingUser || isShouldAuthenticate;
+  const { user } = oidc;
+  const userRequireAuthentication = isRequireAuthentication(user);
   useEffect(() => {
-    if (isShouldAuthenticate) {
+    if (userRequireAuthentication) {
       const userManager = getUserManager();
       authenticateUser(userManager, location, history, user)();
     }
-  }, [isShouldAuthenticate, location, user]);
+  }, [userRequireAuthentication, location, user]);
 
   const AuthenticatingComponent: ComponentType = authenticating || DefaultAuthenticatingComponent;
 
-  return isLoading ? <AuthenticatingComponent /> : <>{children}</>;
+  return userRequireAuthentication ? <AuthenticatingComponent /> : <>{children}</>;
 };
 
 const mapStateToProps = (state: any) => ({
   oidc: state.oidc,
 });
 
-const oidcCompose = compose(
-  connect(
-    mapStateToProps,
-    null
-  ),
-  withRouter
-);
+const oidcCompose = compose(connect(mapStateToProps, null), withRouter);
 
 const Secure = oidcCompose(AuthenticationLiveCycle);
 
@@ -59,8 +52,8 @@ export const oidcSecure = (Component: ComponentType) => (props: any) => {
 };
 
 const propTypesOidcSecure = {
+  children: PropTypes.node.isRequired,
   isEnabled: PropTypes.bool,
-  children: PropTypes.node,
 };
 
 const defaultPropsOidcSecure = {
@@ -80,6 +73,7 @@ type OidcSecureProps = PropsWithChildren<{
 
 const OidcSecure: FC<OidcSecureProps> = props => {
   const { isEnabled, children, ...configProps } = props;
+
   if (isEnabled) {
     return <Secure {...configProps}>{children}</Secure>;
   }

--- a/packages/redux/src/__snapshots__/Oidc.spec.tsx.snap
+++ b/packages/redux/src/__snapshots__/Oidc.spec.tsx.snap
@@ -3,14 +3,6 @@
 exports[`redux.Oidc Render <OidcBaseInternal/> correctly 1`] = `
 <DocumentFragment>
   <p>
-    isEnabled
-  </p>
-</DocumentFragment>
-`;
-
-exports[`redux.Oidc Render <OidcBaseInternal/> correctly when is enabled 1`] = `
-<DocumentFragment>
-  <p>
     Render Something
   </p>
 </DocumentFragment>


### PR DESCRIPTION
fix #403 issue

## Before this PR
![image](https://user-images.githubusercontent.com/20930506/122061092-7c860300-cdee-11eb-96cc-501346e8303f.png)

## After this PR
![image](https://user-images.githubusercontent.com/20930506/122058833-565f6380-cdec-11eb-90a2-06dea0c302a7.png)
![image](https://user-images.githubusercontent.com/20930506/122058921-6bd48d80-cdec-11eb-90f8-5a6a492f2f22.png)

## Notes : 
- OidcSecure.tsx : remove isLoading to harmonize the code with the oidc context package
- Oidc.tsx : make usermanager retrieval synchronous 

- it remains to take into account the <Oidc> isEnabled property to disable authorization properly when set to false (i will fix this in another PR)
