### PR TITLE
add support for defining a base route

### DIFF
--- a/packages/context/src/oidcContext/AuthenticationContext.provider.spec.tsx
+++ b/packages/context/src/oidcContext/AuthenticationContext.provider.spec.tsx
@@ -86,7 +86,8 @@ const propsMocks = {
   },
   authenticateUserInt: jest.fn(() => () => {}),
   logoutUserInt: jest.fn(),
-  setUserManagerInt : jest.fn()
+  setUserManagerInt : jest.fn(),
+  setBaseRouteInt: jest.fn(),
 };
 
 const getWrapper = props => ({ children }) => <AuthenticationProviderInt {...props}>{children}</AuthenticationProviderInt>;

--- a/packages/context/src/oidcContext/AuthenticationContext.provider.tsx
+++ b/packages/context/src/oidcContext/AuthenticationContext.provider.tsx
@@ -14,6 +14,7 @@ import {
   authenticateUser,
   logoutUser,
   setUserManager,
+  setBaseRoute,
 } from '@axa-fr/react-oidc-core';
 
 import { Callback } from '../Callback';
@@ -35,6 +36,7 @@ type AuthenticationProviderIntProps = PropsWithChildren<{
   UserStore: UserStoreType;
   isEnabled?: boolean;
   configuration: UserManagerSettings;
+  baseRoute?: string;
   authenticationServiceInt: typeof authenticationService;
   CallbackInt: typeof Callback;
   setLoggerInt: typeof setLogger;
@@ -44,6 +46,7 @@ type AuthenticationProviderIntProps = PropsWithChildren<{
   logoutUserInt: typeof logoutUser;
   customEvents: CustomEvents;
   setUserManagerInt: typeof setUserManager;
+  setBaseRouteInt: typeof setBaseRoute;
 }>;
 
 const propTypes = {
@@ -105,6 +108,7 @@ export const AuthenticationProviderInt = ({
   callbackComponentOverride,
   children,
   customEvents,
+  baseRoute,
   // Injected
   authenticationServiceInt,
   CallbackInt,
@@ -114,6 +118,7 @@ export const AuthenticationProviderInt = ({
   authenticateUserInt,
   logoutUserInt,
   setUserManagerInt,
+  setBaseRouteInt,
 }: AuthenticationProviderIntProps) => {
   const userManager = authenticationServiceInt(configuration, UserStore);
   const { oidcState, loadUser, onError, onLoading, unloadUser, onLogout } = useAuthenticationContextState(userManager);
@@ -122,6 +127,7 @@ export const AuthenticationProviderInt = ({
 
   useEffect(() => {
     onLoading();
+    setBaseRouteInt(baseRoute);
     setLoggerInt(loggerLevel, logger);
     addOidcEvents();
     let mount = true;
@@ -209,6 +215,7 @@ const AuthenticationProvider: ComponentType<Partial<AuthenticationProviderProps>
     authenticateUserInt: authenticateUser,
     logoutUserInt: logoutUser,
     setUserManagerInt: setUserManager,
+    setBaseRouteInt: setBaseRoute,
   })
 );
 // @ts-ignore

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,4 +14,5 @@ export {
   InMemoryWebStorage,
   UserStoreType,
   setUserManager,
+  setBaseRoute,
 } from './services';

--- a/packages/core/src/routes/OidcRoutes.tsx
+++ b/packages/core/src/routes/OidcRoutes.tsx
@@ -4,6 +4,7 @@ import { UserManagerSettings } from 'oidc-client';
 import { NotAuthenticated, NotAuthorized, SessionLost } from '../default-component';
 import { getPath } from './route-utils';
 import { SilentCallback } from '../callbacks';
+import { getBaseRoute } from '../services';
 
 const propTypes = {
   notAuthenticated: PropTypes.elementType,
@@ -51,17 +52,18 @@ const OidcRoutes: FC<PropsWithChildren<OidcRoutesProps>> = ({
   const SessionLostComponent = sessionLost || SessionLost;
   const silentCallbackPath = getPath(configuration.silent_redirect_uri);
   const callbackPath = getPath(configuration.redirect_uri);
+  const baseRoute = getBaseRoute();
 
   switch (path) {
     case callbackPath:
       return <CallbackComponent />;
     case silentCallbackPath:
       return <SilentCallback />;
-    case '/authentication/not-authenticated':
+    case `${baseRoute}/authentication/not-authenticated`:
       return <NotAuthenticatedComponent />;
-    case '/authentication/not-authorized':
+    case `${baseRoute}/authentication/not-authorized`:
       return <NotAuthorizedComponent />;
-    case '/authentication/session-lost':
+    case `${baseRoute}/authentication/session-lost`:
       return <SessionLostComponent />;
     default:
       return <>{children}</>;

--- a/packages/core/src/routes/withRouter.spec.tsx
+++ b/packages/core/src/routes/withRouter.spec.tsx
@@ -5,6 +5,8 @@ import { withRouter, CreateEvent, WindowInternal } from './withRouter';
 
 describe('WithRouter test Suite', () => {
   const generateKeyMock = () => '123ABC';
+  const getBaseRouteMock = () => '/base';
+
   const paramsMock = { bubbles: false, cancelable: false, detail: 'detail' };
   beforeEach(() => {});
   it('should CreateEvent return correct Event if not on IE', () => {
@@ -65,13 +67,14 @@ describe('WithRouter test Suite', () => {
     const NewComp = withRouter(
       (windowMock as unknown) as WindowInternal,
       createEvent,
-      generateKeyMock
+      generateKeyMock,
+      getBaseRouteMock
     )(Component);
     const { asFragment } = render(<NewComp />);
     expect(windowMock.history.pushState).toHaveBeenCalledWith(
       { key: '123ABC', state: 'state' },
       null,
-      '/url/page'
+      '/base/url/page'
     );
     expect(asFragment()).toMatchSnapshot();
   });

--- a/packages/core/src/services/baseRouteService.spec.ts
+++ b/packages/core/src/services/baseRouteService.spec.ts
@@ -1,0 +1,13 @@
+import * as baseRouteService from './baseRouteService';
+
+describe('BaseRouteService tests suite', () => {
+  it('should get empty string if base route is not set', () => {
+    expect(baseRouteService.getBaseRoute()).toBe('');
+  });
+
+  it('should be able to set base route', () => {
+    const baseRoute = '/test';
+    baseRouteService.setBaseRoute(baseRoute);
+    expect(baseRouteService.getBaseRoute()).toBe(baseRoute);
+  });
+});

--- a/packages/core/src/services/baseRouteService.ts
+++ b/packages/core/src/services/baseRouteService.ts
@@ -1,0 +1,7 @@
+let baseRoute: string;
+
+export const setBaseRoute = (baseRouteToSet: string) => {
+  baseRoute = baseRouteToSet;
+};
+
+export const getBaseRoute = () => baseRoute || '';

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -1,3 +1,4 @@
 export * from './authenticationService';
 export * from './oidcServices';
+export * from './baseRouteService';
 export { oidcLog, setLogger } from './loggerService';


### PR DESCRIPTION
adds support for defining a base route on the provider level. This is useful for apps that only exist on a given base route or have gateway configurations that prevent the user from navigating to routes without a specific base route. 

https://github.com/AxaGuilDEv/react-oidc/issues/586

## Before this PR
apps that exist on a given base route would still navigate to a top-level auth route e.g. `/authentication/not-authenticated

## After this PR
apps that exist on a base route will use the supplied base route and navigate to for ex. `/{baseRoute}/authentication/not-authenticated`

