### PR TITLE
Add button to collapse NavBar

### DIFF
--- a/packages/context/src/App.tsx
+++ b/packages/context/src/App.tsx
@@ -1,20 +1,23 @@
 import React from 'react';
 import { BrowserRouter as Router, Route, Link } from 'react-router-dom';
 import { Home } from "./Home";
-import {Profile, SecureProfile} from "./Profile";
-import {configurationAuth0, configurationIdentityServer} from './configurations';
-import {withOidcSecure,OidcProvider} from "./oidc";
-import {FetchUser} from "./FetchUser";
-import {MultiAuthContainer} from "./MultiAuth";
+import { Profile, SecureProfile } from "./Profile";
+import { configurationAuth0, configurationIdentityServer } from './configurations';
+import { withOidcSecure, OidcProvider } from "./oidc";
+import { FetchUser } from "./FetchUser";
+import { MultiAuthContainer } from "./MultiAuth";
 
 function App() {
-
+  const [show, setShow] = React.useState(false);
   return (
     <OidcProvider configuration={configurationIdentityServer}>
       <Router>
         <nav className="navbar navbar-expand-lg navbar-dark bg-primary">
           <a className="navbar-brand" href="/">@axa-fr/react-oidc-context</a>
-          <div className="collapse navbar-collapse" id="navbarNav">
+          <button className="navbar-toggler" type="button" onClick={() => setShow(!show)} data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span className="navbar-toggler-icon"></span>
+          </button>
+          <div style={show ? { display: "block" } : { display: 'none' }} className="collapse navbar-collapse" id="navbarNav">
             <ul className="navbar-nav">
               <li className="nav-item">
                 <Link className="nav-link" to="/">Home</Link>


### PR DESCRIPTION
## Make the navBar responsive

It's a very little contribution, but in case of debugging with dev tools, in my laptop the navbar is not displayed due to the mid weight width.

## Before this PR
<img width="975" alt="image" src="https://user-images.githubusercontent.com/81740200/156523453-e0bf4c6d-1d8b-46b5-88d6-77842578db6d.png">

## After this PR

 <img width="973" alt="Capture d’écran 2022-03-03 à 09 09 21" src="https://user-images.githubusercontent.com/81740200/156523282-62c27b6e-9a01-4982-8abe-956e204c97cd.png">
<img width="405" alt="Capture d’écran 2022-03-03 à 09 09 13" src="https://user-images.githubusercontent.com/81740200/156523290-92ac001e-4f3c-4150-a14f-19966abc55cd.png">

## Additionnal comment

As you can see in the PR, we don't have the same eslint and prettier config. I think to avoid some useless diff in the commit it could be very usefull to add config inside the project throught a `.eslintrc` and `.prettierrc` file.

Then, in macOS `set PORT=4200` isn't working, what do you think about add [cross env](https://www.npmjs.com/package/cross-env) in dev dependencies ? 

Thanks a lot !

