### PR TITLE
[fix] Make the keepAlive call relative to origin

### DIFF
--- a/packages/context/src/oidc/vanilla/initWorker.ts
+++ b/packages/context/src/oidc/vanilla/initWorker.ts
@@ -33,7 +33,7 @@ let keepAliveServiceWorkerTimeoutId = null;
 
 const keepAlive = () => {
     console.log('/OidcKeepAliveServiceWorker.json');
-    fetch('OidcKeepAliveServiceWorker.json').then(() => {
+    fetch('/OidcKeepAliveServiceWorker.json').then(() => {
         keepAlive();
     })
 }


### PR DESCRIPTION
Make the keepAlive call relative to origin instead  being relative to the current Page.

## A picture tells a thousand words

## Before this PR
The url https://mydomain.com/page1/section1 will result in a call to https://mydomain.com/page1/OidcKeepAliveServiceWorker.json
## After this PR
The url https://mydomain.com/page1/section1 will result in a call to https://mydomain.com/OidcKeepAliveServiceWorker.json