### PR TITLE
refactor(hook): Decoupling user authenticated flag on hook call

### DIFF
--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -299,6 +299,30 @@ const DisplayUserInfo = () => {
 };
 ```
 
+## How to get check if user is authenticated : Hook Method
+
+You can use the `useUserIsAuthenticated()` hook to check if the user is logged-in/authenticated. You can also use the `useOidcUser()` hook as well but this one is less noisy - it does not cause unnecessary re-renders.
+
+```javascript
+import { useUserIsAuthenticated } from '@axa-fr/react-oidc-context';
+
+const DisplayIdToken =() => {
+  const isLoggedIn = useUserIsAuthenticated();
+
+  if(!isLoggedIn){
+    return <p>you are not authentified</p>
+  }
+
+  return (
+          <div className="card text-white bg-info mb-3">
+            <div className="card-body">
+              <h5 className="card-title">User is authenticated! :)</h5>
+            </div>
+          </div>
+  );
+}
+```
+
 # Service Worker Support
 
 - Firefox : tested on firefox 98.0.2

--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -158,7 +158,7 @@ import {useOidc} from "./oidc";
 
 export const Home = () => {
 
-    const { login, logout, isLogged} = useOidc();
+    const { login, logout, isAuthenticated} = useOidc();
     
     return (
         <div className="container-fluid mt-3">
@@ -166,8 +166,8 @@ export const Home = () => {
                 <div className="card-body">
                     <h5 className="card-title">Welcome !!!</h5>
                     <p className="card-text">React Demo Application protected by OpenId Connect</p>
-                    {!isLogged && <button type="button" className="btn btn-primary" onClick={() => login('/profile')}>Login</button>}
-                    {isLogged && <button type="button" className="btn btn-primary" onClick={logout}>logout</button>}
+                    {!isAuthenticated && <button type="button" className="btn btn-primary" onClick={() => login('/profile')}>Login</button>}
+                    {isAuthenticated && <button type="button" className="btn btn-primary" onClick={logout}>logout</button>}
                 </div>
             </div>
         </div>
@@ -176,7 +176,7 @@ export const Home = () => {
 
 ```
 The Hook method exposes : 
-- isLogged : is the user logged?
+- isAuthenticated : if the user is logged in or not
 - logout: logout function (return a promise)
 - login: login function 'return a promise'
 
@@ -194,7 +194,7 @@ const AdminSecure = () => (
   </OidcSecure>
 );
 
-// adding the oidc user in the props
+// adding the oidc user in the propsis
 export default AdminSecure;
 ```
 
@@ -278,49 +278,26 @@ const DisplayIdToken =() => {
 import { useOidcUser } from '@axa-fr/react-oidc-context';
 
 const DisplayUserInfo = () => {
-    const{ oidcUser, isOidcUserLoading, isLogged } = useOidcUser();
+    const{ oidcUser, isOidcUserLoading } = useOidcUser();
 
-    if(isOidcUserLoading) {
+    if(isOidcUserLoading !== UserStatus.Loaded) {
         return <p>User Information are loading</p>
     }
 
-    if(!isLogged){
-        return <p>you are not authentified</p>
+    if(!oidcUser){
+        return <p>you are not authenticated</p>
     }
 
     return (
         <div className="card text-white bg-success mb-3">
             <div className="card-body">
                 <h5 className="card-title">User information</h5>
+                <p>{oidcUser == null && "You are not logged" }</p>
                 {oidcUser != null && <p className="card-text">{JSON.stringify(oidcUser)}</p>}
             </div>
         </div>
     )
 };
-```
-
-## How to get check if user is authenticated : Hook Method
-
-You can use the `useUserIsAuthenticated()` hook to check if the user is logged-in/authenticated. You can also use the `useOidcUser()` hook as well but this one is less noisy - it does not cause unnecessary re-renders.
-
-```javascript
-import { useUserIsAuthenticated } from '@axa-fr/react-oidc-context';
-
-const DisplayIdToken =() => {
-  const isLoggedIn = useUserIsAuthenticated();
-
-  if(!isLoggedIn){
-    return <p>you are not authentified</p>
-  }
-
-  return (
-          <div className="card text-white bg-info mb-3">
-            <div className="card-body">
-              <h5 className="card-title">User is authenticated! :)</h5>
-            </div>
-          </div>
-  );
-}
 ```
 
 # Service Worker Support

--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -194,7 +194,7 @@ const AdminSecure = () => (
   </OidcSecure>
 );
 
-// adding the oidc user in the propsis
+// adding the oidc user in the props
 export default AdminSecure;
 ```
 

--- a/packages/context/package-lock.json
+++ b/packages/context/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axa-fr/react-oidc-context",
-  "version": "4.0.3",
+  "version": "4.5.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@axa-fr/react-oidc-context",
-      "version": "4.0.3",
+      "version": "4.5.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@openid/appauth": "1.3.1",

--- a/packages/context/src/Home.tsx
+++ b/packages/context/src/Home.tsx
@@ -3,16 +3,16 @@ import {useOidc} from "./oidc";
 
 export const Home = () => {
 
-    const { login, logout, isLogged} = useOidc();
-    
+    const { login, logout, isAuthenticated} = useOidc();
+
     return (
         <div className="container-fluid mt-3">
             <div className="card">
                 <div className="card-body">
                     <h5 className="card-title">Home</h5>
                     <p className="card-text">React Demo Application protected by OpenId Connect. More info on about oidc on <a href="https://github.com/AxaGuilDEv/react-oidc">GitHub</a> </p>
-                    {!isLogged && <button type="button" className="btn btn-primary" onClick={() => login('/profile')}>Login</button>}
-                    {isLogged && <button type="button" className="btn btn-primary" onClick={logout}>logout</button>}
+                    {!isAuthenticated && <button type="button" className="btn btn-primary" onClick={() => login('/profile')}>Login</button>}
+                    {isAuthenticated && <button type="button" className="btn btn-primary" onClick={logout}>logout</button>}
                 </div>
             </div>
         </div>

--- a/packages/context/src/MultiAuth.tsx
+++ b/packages/context/src/MultiAuth.tsx
@@ -3,20 +3,20 @@ import {OidcProvider, useOidc, useOidcAccessToken} from "./oidc";
 import { configurationIdentityServer} from "./configurations";
 
 const MultiAuth = ( {configurationName, handleConfigurationChange }) => {
-    const { login, logout, isLogged} = useOidc(configurationName);
+    const { login, logout, isAuthenticated} = useOidc(configurationName);
     return (
         <div className="container-fluid mt-3">
             <div className="card">
                 <div className="card-body">
                     <h5 className="card-title">Work in progress</h5>
-                    <p className="card-text">React Demo Application protected by OpenId Connect with MultipleAUthentication. 
+                    <p className="card-text">React Demo Application protected by OpenId Connect with MultipleAUthentication.
                         <br/>For example, config_1 can have other sensitive scope, config_2 does not ask for the "offline_access" so it does not retrieve the most sensitive token "refresh_token" for very sensitive operation, it retrive only access_token valid for a small amout of time.</p>
                     <select value={configurationName} onChange={handleConfigurationChange} >
                         <option value="config_1">config_1</option>
                         <option value="config_2">config_2</option>
                     </select>
-                    {!isLogged && <button type="button" className="btn btn-primary" onClick={() => login()}>Login</button>}
-                    {isLogged && <button type="button" className="btn btn-primary" onClick={logout}>logout</button>}
+                    {!isAuthenticated && <button type="button" className="btn btn-primary" onClick={() => login()}>Login</button>}
+                    {isAuthenticated && <button type="button" className="btn btn-primary" onClick={logout}>logout</button>}
                 </div>
             </div>
         </div>
@@ -32,21 +32,21 @@ export const MultiAuthContainer = () => {
     const callBack = window.location.origin+"/multi-auth/authentification/callback2";
     const silent_redirect_uri = window.location.origin+"/multi-auth/authentification/silent-callback2";
     const configurations = {
-        config_1: {...configurationIdentityServer, 
-            redirect_uri:callBack, 
+        config_1: {...configurationIdentityServer,
+            redirect_uri:callBack,
             silent_redirect_uri,
             scope: 'openid profile email api offline_access'
         },
-        config_2: {...configurationIdentityServer, 
-            redirect_uri:callBack, 
-            silent_redirect_uri: "", 
+        config_2: {...configurationIdentityServer,
+            redirect_uri:callBack,
+            silent_redirect_uri: "",
             scope: 'openid profile email api'}
     }
     const handleConfigurationChange = (event) => {
         const configurationName = event.target.value;
         sessionStorage.configurationName = configurationName;
         setConfigurationName(configurationName);
-        
+
     }
     return (
         <OidcProvider configuration={configurations[configurationName]} configurationName={configurationName}>

--- a/packages/context/src/Profile.tsx
+++ b/packages/context/src/Profile.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {OidcSecure, useOidcAccessToken, useOidcIdToken, useOidcUser} from "./oidc";
+import {useUserIsAuthenticated} from "./oidc/User";
 
 const DisplayUserInfo = () => {
     const{ oidcUser, isOidcUserLoading, isLogged } = useOidcUser();
@@ -24,10 +25,23 @@ const DisplayUserInfo = () => {
     )
 };
 
+const DisplayUserIsAuthenticated = () => {
+    const isAuthenticated = useUserIsAuthenticated();
+
+    return (
+        <div className={isAuthenticated ? "card text-white bg-success mb-3" : "card text-white bg-warning mb-3"}>
+            <div className="card-body">
+                <h5 className="card-title">{isAuthenticated ? "User is authenticated" : "User is not authenticated"}</h5>
+            </div>
+        </div>
+    )
+}
+
 export const Profile = () => {
 
     return (
        <div className="container mt-3">
+           <DisplayUserIsAuthenticated/>
            <DisplayAccessToken/>
            <DisplayIdToken/>
            <DisplayUserInfo/>
@@ -60,7 +74,7 @@ const DisplayIdToken =() => {
     if(!idToken){
         return <p>you are not authentified</p>
     }
-    
+
     return (
         <div className="card text-white bg-info mb-3">
             <div className="card-body">

--- a/packages/context/src/Profile.tsx
+++ b/packages/context/src/Profile.tsx
@@ -25,23 +25,10 @@ const DisplayUserInfo = () => {
     )
 };
 
-const DisplayUserIsAuthenticated = () => {
-    const {isAuthenticated} = useOidc();
-
-    return (
-        <div className={isAuthenticated ? "card text-white bg-success mb-3" : "card text-white bg-warning mb-3"}>
-            <div className="card-body">
-                <h5 className="card-title">{isAuthenticated ? "User is authenticated" : "User is not authenticated"}</h5>
-            </div>
-        </div>
-    )
-}
-
 export const Profile = () => {
 
     return (
        <div className="container mt-3">
-           <DisplayUserIsAuthenticated/>
            <DisplayAccessToken/>
            <DisplayIdToken/>
            <DisplayUserInfo/>

--- a/packages/context/src/Profile.tsx
+++ b/packages/context/src/Profile.tsx
@@ -4,10 +4,14 @@ import {OidcSecure, useOidc, useOidcAccessToken, useOidcIdToken, useOidcUser} fr
 import {UserStatus} from "./oidc/User";
 
 const DisplayUserInfo = () => {
-    const{ oidcUser, isOidcUserLoading } = useOidcUser();
+    const{ oidcUser, oidcUserLoadingState } = useOidcUser();
 
-    if(isOidcUserLoading !== UserStatus.Loaded) {
+    if(oidcUserLoadingState === UserStatus.Loading) {
         return <p>User Information are loading</p>
+    }
+
+    if(oidcUserLoadingState === UserStatus.LoadingError) {
+        return <p>User Information loading errored.</p>
     }
 
     if(!oidcUser){

--- a/packages/context/src/Profile.tsx
+++ b/packages/context/src/Profile.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 
-import {OidcSecure, useOidcAccessToken, useOidcIdToken, useOidcUser} from "./oidc";
-import {useUserIsAuthenticated} from "./oidc/User";
+import {OidcSecure, useOidc, useOidcAccessToken, useOidcIdToken, useOidcUser} from "./oidc";
+import {UserStatus} from "./oidc/User";
 
 const DisplayUserInfo = () => {
-    const{ oidcUser, isOidcUserLoading, isLogged } = useOidcUser();
+    const{ oidcUser, isOidcUserLoading } = useOidcUser();
 
-    if(isOidcUserLoading) {
+    if(isOidcUserLoading !== UserStatus.Loaded) {
         return <p>User Information are loading</p>
     }
 
-    if(!isLogged){
-        return <p>you are not authentified</p>
+    if(!oidcUser){
+        return <p>you are not authenticated</p>
     }
 
     return (
@@ -26,7 +26,7 @@ const DisplayUserInfo = () => {
 };
 
 const DisplayUserIsAuthenticated = () => {
-    const isAuthenticated = useUserIsAuthenticated();
+    const {isAuthenticated} = useOidc();
 
     return (
         <div className={isAuthenticated ? "card text-white bg-success mb-3" : "card text-white bg-warning mb-3"}>
@@ -53,7 +53,7 @@ const DisplayAccessToken = () => {
     const{ accessToken, accessTokenPayload } = useOidcAccessToken();
 
     if(!accessToken){
-        return <p>you are not authentified</p>
+        return <p>you are not authenticated</p>
     }
     return (
         <div className="card text-white bg-info mb-3">
@@ -72,7 +72,7 @@ const DisplayIdToken =() => {
     const{ idToken, idTokenPayload } = useOidcIdToken();
 
     if(!idToken){
-        return <p>you are not authentified</p>
+        return <p>you are not authenticated</p>
     }
 
     return (

--- a/packages/context/src/oidc/ReactOidc.tsx
+++ b/packages/context/src/oidc/ReactOidc.tsx
@@ -4,21 +4,21 @@ import Oidc from "./vanilla/oidc";
 const defaultConfigurationName = "default";
 export const useOidc =(configurationName=defaultConfigurationName) =>{
     const getOidc =  Oidc.get;
-   
+
     const login = (callbackPath=undefined) => {
         return getOidc(configurationName).loginAsync(callbackPath);
     };
     const logout = () => {
         return getOidc(configurationName).logoutAsync();
     };
-    
-    let isLogged = false;
+
+    let isAuthenticated = false;
     const oidc = getOidc(configurationName);
     if(oidc){
-        isLogged = getOidc(configurationName).tokens != null;
+        isAuthenticated = getOidc(configurationName).tokens != null;
     }
-    
-    return {login, logout, isLogged };
+
+    return { login, logout, isAuthenticated };
 }
 
 const accessTokenInitialState = {accessToken:null, accessTokenPayload:null};
@@ -37,7 +37,7 @@ export const useOidcAccessToken =(configurationName=defaultConfigurationName) =>
     const getOidc =  Oidc.get;
     const [state, setAccessToken] = useState<any>(initTokens(configurationName));
     const [subscriptionId, setSubscriptionId] = useState(null);
-    
+
     useEffect(() => {
         let isMounted = true;
         const oidc = getOidc(configurationName);
@@ -60,7 +60,7 @@ export const useOidcAccessToken =(configurationName=defaultConfigurationName) =>
         if(isMounted){
             setSubscriptionId(newSubscriptionId);
         }
-        return  () => { 
+        return  () => {
             isMounted = false;
             oidc.removeEventSubscription(subscriptionId);
         };
@@ -84,14 +84,14 @@ export const useOidcIdToken =(configurationName= defaultConfigurationName) =>{
     const getOidc =  Oidc.get;
     const [state, setIDToken] = useState<any>(idTokenInitialState);
     const [subscriptionId, setSubscriptionId] = useState(initIdToken(configurationName));
-    
+
     useEffect(() => {
         let isMounted = true;
         const oidc = getOidc(configurationName);
         if(oidc.tokens) {
             const tokens = oidc.tokens;
             setIDToken({idToken: tokens.idToken, idTokenPayload:tokens.idTokenPayload});
-        } 
+        }
         if(subscriptionId){
             oidc.removeEventSubscription(subscriptionId);
         }

--- a/packages/context/src/oidc/User.ts
+++ b/packages/context/src/oidc/User.ts
@@ -4,7 +4,8 @@ import Oidc from "./vanilla/oidc";
 export enum UserStatus {
     Unauthenticated= 'Unauthenticated',
     Loading = 'Loading user',
-    Loaded = 'User loaded'
+    Loaded = 'User loaded',
+    LoadingError = 'Error loading user'
 }
 
 type OidcUser = {
@@ -27,11 +28,11 @@ export const useOidcUser = (configurationName="default") => {
                         setOidcUser({user: info, status: UserStatus.Loaded});
                     }
                 })
-                .catch(() => setOidcUser({...oidcUser, status: UserStatus.Unauthenticated}));
+                .catch(() => setOidcUser({...oidcUser, status: UserStatus.LoadingError}));
         }
 
         return  () => { isMounted = false };
     }, []);
 
-    return {oidcUser: oidcUser.user, isOidcUserLoading: oidcUser.status}
+    return {oidcUser: oidcUser.user, oidcUserLoadingState: oidcUser.status}
 }

--- a/packages/context/src/oidc/User.ts
+++ b/packages/context/src/oidc/User.ts
@@ -20,12 +20,16 @@ export const useOidcUser =(configurationName="default") => {
         }
         return  () => { isMounted = false };
     }, [])
-    
+
     let isLogged = false;
     const oidc = getOidc(configurationName);
     if(oidc){
         isLogged = oidc.tokens != null;
     }
-    
+
     return {oidcUser, isOidcUserLoading, isLogged: isLogged}
+}
+
+export const useUserIsAuthenticated =(configurationName="default") => {
+    return Oidc.get(configurationName).tokens != null
 }


### PR DESCRIPTION
Hey there! Love this library, it's really neat, huge props! 🎉 

This PR attempts to decouple the information from the `useOidcUser()` hook. I am aware that I can use the `withOidcSecure()` hook to secure a component to check if the user is authenticated or not and redirect to the login page. However, the latter is not useful when I'm dealing with multiple libraries for different providers (e.g., I use the [`msal-react`](https://www.npmjs.com/package/@azure/msal-react) library for Azure sign-in alongside this one for other on-prem identity providers like IdentityServer or CAS Apereo).

I'm decoupling because `useOidcUser()` causes unnecessary re-renders when I only want to know if the user is authenticated or not. This greatly  impacts the performance of my application currently, especially if it's a root component.

## A picture tells a thousand words

#### Current hook

The following picture shows me rendering a new component on the demo project and showing the amount of times it renders when I'm calling:

```
    const isAuthenticated = useOidcUser().isLogged;     // -> the old one
    console.log("render")

    return (
        <div className={isAuthenticated ? "card text-white bg-success mb-3" : "card text-white bg-warning mb-3"}>
            <div className="card-body">
                <h5 className="card-title">{isAuthenticated ? "User is authenticated" : "User is not authenticated"}</h5>
            </div>
        </div>
    )
```

![image](https://user-images.githubusercontent.com/17494745/161082583-8e56f791-bee7-4c8c-9711-00c008eeff44.png)

#### New hook
With the new hook I added - `useUserIsAuthenticated()` - it only renders once 😄 .

```
    const isAuthenticated = useUserIsAuthenticated();    // -> the new one
    console.log("render")

    return (
        <div className={isAuthenticated ? "card text-white bg-success mb-3" : "card text-white bg-warning mb-3"}>
            <div className="card-body">
                <h5 className="card-title">{isAuthenticated ? "User is authenticated" : "User is not authenticated"}</h5>
            </div>
        </div>
    )
```

![image](https://user-images.githubusercontent.com/17494745/161083050-4089c3fb-d5d9-4dc6-b2cb-40aa4613f4d8.png)

This logic of decoupling hooks can further be extended to the rest of the components of `useOidcUser()`, even though I guess this one is more alarming, in my opinion. This is useful so I don't have to use libraries like [`react-hooks-in-callback`](https://github.com/fernandoem88/react-hooks-in-callback) to control re-renders. 
