### PR TITLE
feat(oidc): NextJS  Compatibility

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -156,6 +156,7 @@ const propTypes = {
     service_worker_relative_url: PropTypes.string,
     service_worker_only: PropTypes.boolean, // default false
     extras: StringMap|undefined // ex: {'prompt': 'consent', 'access_type': 'offline'} list of key/value that are send to the oidc server (more info: https://github.com/openid/AppAuth-JS)
+    withCustomHistory: PropTypes.function, // Override history modification, return instance with replaceState(url, stateHistory) implemented (like History.replaceState()) 
   }).isRequired
 };
 ```

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -155,7 +155,7 @@ const propTypes = {
     refresh_time_before_tokens_expiration_in_second: PropTypes.number,
     service_worker_relative_url: PropTypes.string,
     service_worker_only: PropTypes.boolean, // default false
-    extras: StringMap|undefined // ex: {'prompt': 'consent', 'access_type': 'offline'} list of key/value that are send to the oidc server (more info: https://github.com/openid/AppAuth-JS)
+    extras: StringMap|undefined, // ex: {'prompt': 'consent', 'access_type': 'offline'} list of key/value that are send to the oidc server (more info: https://github.com/openid/AppAuth-JS)
     withCustomHistory: PropTypes.function, // Override history modification, return instance with replaceState(url, stateHistory) implemented (like History.replaceState()) 
   }).isRequired
 };

--- a/packages/react/src/oidc/OidcProvider.tsx
+++ b/packages/react/src/oidc/OidcProvider.tsx
@@ -4,6 +4,7 @@ import OidcRoutes from './core/routes/OidcRoutes';
 import {Authenticating, AuthenticateError, SessionLost, Loading, CallBackSuccess} from './core/default-component/index';
 import ServiceWorkerNotSupported from "./core/default-component/ServiceWorkerNotSupported.component";
 import AuthenticatingError from "./core/default-component/AuthenticateError.component";
+import { CustomHistory } from "./core/routes/withRouter";
 
 export type oidcContext = {
     getOidc: Function;
@@ -23,6 +24,7 @@ export type OidcProviderProps = {
     configuration?: OidcConfiguration;
     children: any;
     onSessionLost?: Function,
+    withCustomHistory?: () => CustomHistory,
 };
 
 export type OidcSessionProps = {
@@ -79,7 +81,9 @@ export const OidcProvider : FC<PropsWithChildren<OidcProviderProps>>  = ({ child
                                                                              serviceWorkerNotSupportedComponent = ServiceWorkerNotSupported,
                                                                              authenticatingErrorComponent = AuthenticatingError,
                                                                              sessionLostComponent=SessionLost,
-                                                                             onSessionLost=null}) => {
+                                                                             onSessionLost=null,
+                                                                             withCustomHistory=null,
+                                                                         }) => {
     const getOidc =(configurationName="default") => {
         return Oidc.getOrCreate(configuration, configurationName);
     }
@@ -152,7 +156,8 @@ export const OidcProvider : FC<PropsWithChildren<OidcProviderProps>>  = ({ child
                                   callbackSuccessComponent={callbackSuccessComponent} 
                                   callbackErrorComponent={callbackErrorComponent}
                                   authenticatingComponent={authenticatingComponent}
-                                  configurationName={configurationName}>
+                                  configurationName={configurationName}
+                                  withCustomHistory={withCustomHistory}>
                           <OidcSession loadingComponent={LoadingComponent} configurationName={configurationName}>
                             {children}
                           </OidcSession>

--- a/packages/react/src/oidc/core/default-component/Callback.component.tsx
+++ b/packages/react/src/oidc/core/default-component/Callback.component.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useState, ComponentType} from 'react';
-import {getCustomHistory} from "../routes/withRouter";
 import AuthenticatingError from "./AuthenticateError.component";
 import Oidc from "../../vanilla/oidc";
+import {getCustomHistory} from "../routes/withRouter";
 
 export const CallBackSuccess: ComponentType<any> = () =>  (<div className="oidc-callback">
   <div className="oidc-callback__container">
@@ -10,7 +10,7 @@ export const CallBackSuccess: ComponentType<any> = () =>  (<div className="oidc-
   </div>
 </div>);
 
-const CallbackManager: ComponentType<any> = ({callBackError, callBackSuccess, configurationName }) => {
+const CallbackManager: ComponentType<any> = ({callBackError, callBackSuccess, configurationName, withCustomHistory }) => {
   const getOidc =  Oidc.get;
   const [error, setError] = useState(false);
 
@@ -24,7 +24,7 @@ const CallbackManager: ComponentType<any> = ({callBackError, callBackSuccess, co
       try {
         const state = await getOidc(configurationName).loginCallbackWithAutoTokensRenewAsync();
         if (isMounted) {
-            const history = getCustomHistory()
+            const history = (withCustomHistory)? withCustomHistory(): getCustomHistory();
             history.replaceState(decodeURIComponent(state || "/"))
         }
       } catch (error) {

--- a/packages/react/src/oidc/core/routes/OidcRoutes.tsx
+++ b/packages/react/src/oidc/core/routes/OidcRoutes.tsx
@@ -4,6 +4,7 @@ import { getPath } from './route-utils';
 import CallbackComponent from '../default-component/Callback.component';
 import SilentCallbackComponent from "../default-component/SilentCallback.component";
 import ServiceWorkerInstall from "../default-component/ServiceWorkerInstall.component";
+import { CustomHistory } from "./withRouter";
 
 const propTypes = {
   callbackComponent: PropTypes.elementType,
@@ -22,6 +23,7 @@ type OidcRoutesProps = {
   configurationName:string;
   redirect_uri: string;
   silent_redirect_uri?: string;
+  withCustomHistory?: () => CustomHistory;
 };
 
 const OidcRoutes: FC<PropsWithChildren<OidcRoutesProps>> = ({
@@ -30,7 +32,8 @@ const OidcRoutes: FC<PropsWithChildren<OidcRoutesProps>> = ({
                                                               authenticatingComponent,  
                                                               redirect_uri,
                                                               silent_redirect_uri,
-  children, configurationName
+  children, configurationName,
+  withCustomHistory=null,
 }) => {
   // This exist because in next.js window outside useEffect is null
   const pathname = window ? window.location.pathname : '';
@@ -54,7 +57,7 @@ const OidcRoutes: FC<PropsWithChildren<OidcRoutesProps>> = ({
 
   switch (path) {
     case callbackPath:
-      return <CallbackComponent callBackError={callbackErrorComponent} callBackSuccess={callbackSuccessComponent} configurationName={configurationName} />;
+      return <CallbackComponent callBackError={callbackErrorComponent} callBackSuccess={callbackSuccessComponent} configurationName={configurationName} withCustomHistory={withCustomHistory} />;
     case callbackPath +"/service-worker-install" :
       return <ServiceWorkerInstall callBackError={callbackErrorComponent} authenticating={authenticatingComponent} configurationName={configurationName} />;  
     default:

--- a/packages/react/src/oidc/core/routes/withRouter.tsx
+++ b/packages/react/src/oidc/core/routes/withRouter.tsx
@@ -42,11 +42,15 @@ export interface ReactOidcHistory {
   replaceState: (url?: string | null, stateHistory?: WindowHistoryState) => void;
 }
 
+export type CustomHistory = {
+  replaceState(url?: string | null, stateHistory?: WindowHistoryState): void;
+}
+
 const getHistory = (
   windowInternal: WindowInternal,
   CreateEventInternal: (event: string, params?: InitCustomEventParams) => CustomEvent,
   generateKeyInternal: typeof generateKey
-) => {
+): CustomHistory => {
   return {
     replaceState: (url?: string | null, stateHistory?: WindowHistoryState): void => {
       const key = generateKeyInternal();

--- a/packages/react/src/oidc/vanilla/timer.ts
+++ b/packages/react/src/oidc/vanilla/timer.ts
@@ -90,11 +90,15 @@
     }());
 
     if (!workerPort) {
+        // In NextJS with SSR (Server Side Rendering) during rending in Node JS, the window object is undefined,
+        // the global object is used instead as it is the closest approximation of a browsers window object.
+        const bindContext = (typeof window === 'undefined')? global: window;
+
         return {
-            setTimeout: setTimeout.bind(window),
-            clearTimeout: clearTimeout.bind(window),
-            setInterval: setInterval.bind(window),
-            clearInterval: clearInterval.bind(window)
+            setTimeout: setTimeout.bind(bindContext),
+            clearTimeout: clearTimeout.bind(bindContext),
+            setInterval: setInterval.bind(bindContext),
+            clearInterval: clearInterval.bind(bindContext)
         };
     }
 


### PR DESCRIPTION
## Before this PR

Could not use **react-oidc** in ***NextJS*** based application, because ***Server Side Rendering*** (aka ***SSR***) would fail on `undefined` reference to `window`.

Additionally, on redirect back to the ***NextJS*** application, the final redirect would not work properly, the router would not detect the URL/History changes. 


## After this PR

In NodeJS the window object does not exists, the global object is the closes alternative. When **react-oidc** is executed on the server side (in Node JS), it uses `global` object conditionally instead of `window`.

When returning back from the IDP, the default URL/History modification is not detected by ***NextJS*** router. The `CallbackManager` has been extended to allow an externally defined custom history object witch implements the `replaceState` method. By extending the `CallbackManager` in this way, we can use the native NextJS router to handle URL/History changes by providing a custom implementation.

Changes introduced:

 * In `Timer.js` when `window` is **undefined**, `global` object is used instead (prevents SSR errors)
 * Extended interface, to allow passing custom history object via `withCustomHistory` prop