### PR TITLE
Add source code to context package

### DIFF
--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -11,6 +11,7 @@
   },
   "files": [
     "dist",
+    "src",
     "react",
     "README.md",
     "tsconfig.json",


### PR DESCRIPTION
Source maps don't really work if the files that they refer to are not present in the package.

This change brings the context package in line with the react package, which correctly includes the `src` directory.

This was originally addressed as part of #741, but the change seems to have been reversed in 403f28d0e1ad121bc4fbf7f76ee381c98a120d8f.