### PR TITLE
fix(oidcprovider): remove semicolon from error output

### DIFF
--- a/packages/react/src/oidc/OidcProvider.tsx
+++ b/packages/react/src/oidc/OidcProvider.tsx
@@ -175,7 +175,7 @@ export const OidcProvider : FC<PropsWithChildren<OidcProviderProps>>  = ({ child
         case Oidc.eventNames.loginAsync_error:
         case Oidc.eventNames.loginCallbackAsync_error:
             return <Switch loadingComponent={LoadingComponent} isLoading={isLoading} configurationName={configurationName}>
-                <AuthenticatingErrorComponent configurationName={configurationName} />;
+                <AuthenticatingErrorComponent configurationName={configurationName} />
             </Switch>;
         case Oidc.eventNames.refreshTokensAsync_error:
         case Oidc.eventNames.syncTokensAsync_error:


### PR DESCRIPTION
## A picture tells a thousand words
![error](https://user-images.githubusercontent.com/233300/182580122-44ce076f-7559-4b29-8c00-811477ff143a.png)

## Before this PR
Semicolon would occur after login errors in output.

## After this PR
Semicolon will not occur after login errors in output.
