### PR TITLE
fix(type): Expose fetch type from "useOidcFetch" correctly

### DIFF
--- a/packages/react/src/oidc/FetchToken.tsx
+++ b/packages/react/src/oidc/FetchToken.tsx
@@ -12,7 +12,7 @@ export interface ComponentWithOidcFetchProps {
 const defaultConfigurationName = "default";
 
 const fetchWithToken = (fetch: Fetch, getOidcWithConfigurationName: () => Oidc | null) => async (...params: Parameters<Fetch>) => {
-  const [url, options] = params;
+  const [url, options, ...rest] = params;
   const optionTmp = options ? { ...options} : { method: "GET" };
   
   let headers = new Headers();
@@ -39,7 +39,7 @@ const fetchWithToken = (fetch: Fetch, getOidcWithConfigurationName: () => Oidc |
     }
   }
   const newOptions = { ...optionTmp, headers };
-  return await fetch(url, newOptions);
+  return await fetch(url, newOptions, ...rest);
 };
 
 export const withOidcFetch = (fetch: Fetch = null, configurationName = defaultConfigurationName) => (


### PR DESCRIPTION
## A picture tells a thousand words
![Explanation](https://user-images.githubusercontent.com/14359461/192513569-4b1d961a-9f6a-4f2a-bfb5-ea96b8c23b75.png)

## Before this PR
The type of the fetch object that `useOidFetch` exposes does not match the type signature of the global `fetch` function, which makes it a bit difficult to make wrapper hooks (or other things) on top of this fetch instance.

## After this PR
By using typescript to extract the parameters of the global `fetch` type and passing them back into `fetchWithToken` it keeps the method signature identical, after that we can use the spread syntax to expand the parameters back into the original requested arguments.