### PR TITLE
task(config): Set jsx type to "react-jsx".  Remove npm i task in build

### DIFF
--- a/packages/context/tsconfig.json
+++ b/packages/context/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es5",
     "lib": ["es2015", "dom"],
     "outDir": "dist",
-    "jsx": "react",
+    "jsx": "react-jsx",
     "module": "commonjs",
     "declaration": true,
     "declarationMap": true,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "copy": "copyfiles -f ./src/oidc/vanilla/OidcServiceWorker.js ./public && copyfiles -f -soft ./src/oidc/vanilla/OidcTrustedDomains.js ./public",
     "start": "npm run copy && cross-env PORT=4200 react-scripts start",
-    "build": "npm i react react-dom && npm run copy && react-scripts build",
+    "build": "npm run copy && react-scripts build",
     "test": "react-scripts test --coverage",
     "eject": "react-scripts eject",
     "clean": "rimraf dist",

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2015",
     "lib": ["ES2015", "DOM"],
     "outDir": "dist",
-    "jsx": "react",
+    "jsx": "react-jsx",
     "module": "CommonJS",
     "declaration": true,
     "declarationMap": true,

--- a/packages/vanilla/tsconfig.json
+++ b/packages/vanilla/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es5",
     "lib": ["es2015", "dom"],
     "outDir": "dist",
-    "jsx": "react",
+    "jsx": "react-jsx",
     "module": "commonjs",
     "types": [
       "node"


### PR DESCRIPTION
- set jsx type to `react-jsx` (https://stackoverflow.com/questions/67776707/ts-config-jsx-reactjsx-vs-react)
- remove `npm i` call from package.json `build`, should not be required.
