### PR TITLE
fix(errorMessages): Error message to show correct filename

### DIFF
--- a/packages/react/src/oidc/vanilla/OidcServiceWorker.js
+++ b/packages/react/src/oidc/vanilla/OidcServiceWorker.js
@@ -386,7 +386,7 @@ const checkDomain = (domains, endpoint) => {
 
     const domain = domains.find(domain => endpoint.startsWith(domain));
     if (!domain) {
-        throw new Error(`Domain ${endpoint} is not trusted, please add domain in ${scriptFilename}`);
+        throw new Error('Domain ' + endpoint + ' is not trusted, please add domain in ' + scriptFilename);
     }
 };
 

--- a/packages/react/src/oidc/vanilla/OidcServiceWorker.js
+++ b/packages/react/src/oidc/vanilla/OidcServiceWorker.js
@@ -1,5 +1,5 @@
-/* global trustedDomains */
-this.importScripts('OidcTrustedDomains.js');
+﻿const scriptFilename = 'OidcTrustedDomains.js'; /* global trustedDomains */
+this.importScripts(scriptFilename);
 
 const id = Math.round(new Date().getTime() / 1000).toString();
 
@@ -386,7 +386,7 @@ const checkDomain = (domains, endpoint) => {
 
     const domain = domains.find(domain => endpoint.startsWith(domain));
     if (!domain) {
-        throw new Error('Domain ' + endpoint + ' is not trusted, please add domain in TrustedDomains.js');
+        throw new Error(`Domain ${endpoint} is not trusted, please add domain in ${scriptFilename}`);
     }
 };
 


### PR DESCRIPTION
Error message to show correct filename `OidcTrustedDomains.js` instead of `TrustedDomains.js`
Aligns to actual filename in repository.

## Before this PR

thrown Error would show

```text
is not trusted, please add domain in TrustedDomains.js
```

## After this PR

```text
is not trusted, please add domain in OidcTrustedDomains.js
```