### PR TITLE
feat(regex-domain-support): update oidcserviceworker to support regex match

### DIFF
--- a/packages/react/src/oidc/vanilla/OidcServiceWorker.js
+++ b/packages/react/src/oidc/vanilla/OidcServiceWorker.js
@@ -214,18 +214,15 @@ const getCurrentDatabaseDomain = (database, url) => {
             hasToSendToken = true;
         } else {
             for (let i = 0; i < domainsToSendTokens.length; i++) {
-                const domain = domainsToSendTokens[i];
-                
+                let domain = domainsToSendTokens[i];
+
                 if (typeof domain === 'string') {
-                    if (url.startsWith(domain)) {
-                        hasToSendToken = true;
-                        break;
-                    }
-                } else {
-                    if (domain.test?.(url)) {
-                        hasToSendToken = true;
-                        break;
-                    }
+                    domain = new RegExp(`^${domain}`, 'gm');
+                }
+
+                if (domain.test?.(url)) {
+                    hasToSendToken = true;
+                    break;
                 }
             }
         }
@@ -393,13 +390,13 @@ const checkDomain = (domains, endpoint) => {
     }
 
     const domain = domains.find((domain) => {
+        let testable = domain;
+
         if (typeof domain === 'string') {
-            return endpoint.startsWith(domain);
-        } else if (typeof domain === 'object') {
-            return domain.test?.(endpoint);
+            testable = new RegExp(`^${domain}`, 'gm');
         }
-        
-        return false;
+
+        return testable.test?.(endpoint);
     });
     if (!domain) {
         throw new Error('Domain ' + endpoint + ' is not trusted, please add domain in ' + scriptFilename);

--- a/packages/react/src/oidc/vanilla/OidcServiceWorker.js
+++ b/packages/react/src/oidc/vanilla/OidcServiceWorker.js
@@ -215,9 +215,17 @@ const getCurrentDatabaseDomain = (database, url) => {
         } else {
             for (let i = 0; i < domainsToSendTokens.length; i++) {
                 const domain = domainsToSendTokens[i];
-                if (url.startsWith(domain)) {
-                    hasToSendToken = true;
-                    break;
+                
+                if (typeof domain === 'string') {
+                    if (url.startsWith(domain)) {
+                        hasToSendToken = true;
+                        break;
+                    }
+                } else {
+                    if (domain.test?.(url)) {
+                        hasToSendToken = true;
+                        break;
+                    }
                 }
             }
         }
@@ -384,7 +392,15 @@ const checkDomain = (domains, endpoint) => {
         return;
     }
 
-    const domain = domains.find(domain => endpoint.startsWith(domain));
+    const domain = domains.find((domain) => {
+        if (typeof domain === 'string') {
+            return endpoint.startsWith(domain);
+        } else if (typeof domain === 'object') {
+            return domain.test?.(endpoint);
+        }
+        
+        return false;
+    });
     if (!domain) {
         throw new Error('Domain ' + endpoint + ' is not trusted, please add domain in ' + scriptFilename);
     }


### PR DESCRIPTION
## A picture tells a thousand words

```
const HOSTS = [
  'http://localhost:8080',
  new RegExp('(http://[a-zA-Z0-9-]+.abc.com/users/)', 'g'),
  new RegExp('(https://[a-zA-Z0-9-]+.xyz.app/api/)', 'g'),
];

const trustedDomains = {
  default: HOSTS,
  config_classic: HOSTS,
}
```

A better way to go about is also to make everything as regex (internally to support backwards compatibility) and get rid of the 2 step if-else condition. 