### PR TITLE
fix: remove global regex and use without flags

### DIFF
--- a/packages/react/src/oidc/vanilla/OidcServiceWorker.js
+++ b/packages/react/src/oidc/vanilla/OidcServiceWorker.js
@@ -217,7 +217,7 @@ const getCurrentDatabaseDomain = (database, url) => {
                 let domain = domainsToSendTokens[i];
 
                 if (typeof domain === 'string') {
-                    domain = new RegExp(`^${domain}`, 'gm');
+                    domain = new RegExp(`^${domain}`);
                 }
 
                 if (domain.test?.(url)) {
@@ -393,7 +393,7 @@ const checkDomain = (domains, endpoint) => {
         let testable = domain;
 
         if (typeof domain === 'string') {
-            testable = new RegExp(`^${domain}`, 'gm');
+            testable = new RegExp(`^${domain}`);
         }
 
         return testable.test?.(endpoint);

--- a/readme.md
+++ b/readme.md
@@ -155,7 +155,7 @@ render(<App />, document.getElementById('root'));
 
 // Domains used by OIDC server must be also declared here
 const trustedDomains = {
-  default:["https://demo.duendesoftware.com", "https://www.myapi.com/users"]
+  default:["https://demo.duendesoftware.com", "https://www.myapi.com/users", new RegExp('^(https://[a-zA-Z0-9-]+.domain.com/api/)')]
 };
 ```
 


### PR DESCRIPTION
## A picture tells a thousand words

"JavaScript [RegExp](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) objects are stateful when they have the [global](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/global) or [sticky](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky) flags"

Since the g flag was used in regex, it caused matches to fail everytime the regex was run. If your client had a higher time set for refreshing access token, the first request would fail and the rest would succeed. And if the time to refresh access token is shorter, all the requests would fail with a 401.

Reason: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test
