### PR TITLE
feat(oidc): Adding ability to convert all service worker requests to cors

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -148,6 +148,7 @@ const propTypes = {
     refresh_time_before_tokens_expiration_in_second: PropTypes.number,
     service_worker_relative_url: PropTypes.string,
     service_worker_only: PropTypes.boolean, // default false
+    service_worker_convert_all_requests_to_cors: PropTypes.boolean, // force all requests that servie worker upgrades to have 'cors' mode. This allows setting authentication token on requests initialted by html parsing(e.g. img tags, download links etc).
     extras: StringMap | undefined, // ex: {'prompt': 'consent', 'access_type': 'offline'} list of key/value that are send to the oidc server (more info: https://github.com/openid/AppAuth-JS)
     token_request_extras: StringMap | undefined, // ex: {'prompt': 'consent', 'access_type': 'offline'} list of key/value that are send to the oidc server during token request (more info: https://github.com/openid/AppAuth-JS)
     withCustomHistory: PropTypes.function, // Override history modification, return instance with replaceState(url, stateHistory) implemented (like History.replaceState())

--- a/packages/react/src/oidc/vanilla/OidcServiceWorker.js
+++ b/packages/react/src/oidc/vanilla/OidcServiceWorker.js
@@ -286,6 +286,7 @@ const handleFetch = async (event) => {
                 ...serializeHeaders(originalRequest.headers),
                 authorization: 'Bearer ' + currentDatabaseForRequestAccessToken.tokens.access_token,
             },
+            mode: currentDatabaseForRequestAccessToken.oidcConfiguration.service_worker_convert_all_requests_to_cors ? "cors" : originalRequest.mode,
         });
         event.waitUntil(event.respondWith(fetch(newRequest)));
         return;

--- a/packages/react/src/oidc/vanilla/types.ts
+++ b/packages/react/src/oidc/vanilla/types.ts
@@ -13,6 +13,7 @@ export type OidcConfiguration = {
     token_request_timeout?: number;
     service_worker_relative_url?:string;
     service_worker_only?:boolean;
+    service_worker_convert_all_requests_to_cors?:boolean;
     extras?:StringMap;
     token_request_extras?:StringMap;
     storage?: Storage;


### PR DESCRIPTION
#791  - Adding ability to convert service worker upgrades to use cors mode. This allows correct token processing for requests that are not cors initially, e.g. coming from img tags or download links.

## Before this PR
When you try to show images that require authentication to access service worker was not able to attach authorization header because request was non-cors and it only allows simple headers.

## After this PR
We can configure to upgrade all requests service worker intercepts to cors mode.