### PR TITLE
fix(oidc): Add missing groups attribute

### DIFF
--- a/packages/react/src/oidc/vanilla/vanillaOidc.ts
+++ b/packages/react/src/oidc/vanilla/vanillaOidc.ts
@@ -95,6 +95,7 @@ export interface OidcUserInfo {
     phone_number_verified?: boolean;
     address?: OidcAddressClaim;
     updated_at?: number;
+    groups?: string[]
 }
 
 export interface OidcAddressClaim {


### PR DESCRIPTION
When adding groups as scope to oidc settings file, the OidcUserInfo is missing this attribute