### PR TITLE
fix: lint error missing semicolon

### DIFF
--- a/packages/react/src/oidc/vanilla/vanillaOidc.ts
+++ b/packages/react/src/oidc/vanilla/vanillaOidc.ts
@@ -95,7 +95,7 @@ export interface OidcUserInfo {
     phone_number_verified?: boolean;
     address?: OidcAddressClaim;
     updated_at?: number;
-    groups?: string[]
+    groups?: string[];
 }
 
 export interface OidcAddressClaim {


### PR DESCRIPTION
Fix lint error
```js
src\oidc\vanilla\vanillaOidc.ts
  Line 98:22:  Expected a semicolon  @typescript-eslint/member-delimiter-style
```