### PR TITLE
refactor(types): Improve types in OidcServiceWorker. 

### DIFF
--- a/packages/react/service_worker/.eslintrc.js
+++ b/packages/react/service_worker/.eslintrc.js
@@ -1,0 +1,18 @@
+module.exports = {
+  extends: [__dirname + '/config/defaultEslintConfig'],
+  parserOptions: {
+    project: '../tsconfig.eslint.json',
+    tsconfigRootDir: __dirname,
+  },
+  rules: {
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        selector: 'variable',
+        types: ['boolean'],
+        format: ['PascalCase'],
+        prefix: ['is', 'with', 'should', 'has', 'can', 'did', 'will'],
+      },
+    ],
+  },
+};

--- a/packages/react/service_worker/tsconfig.json
+++ b/packages/react/service_worker/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "rootDir": ".",
     "composite": true,


### PR DESCRIPTION
Improve the types in OidcSerivceWorker

@guillaume-chervet  Could you please look at the below lines.  I've had to ts-ignore two of the lines because of invalid return types. Is what is there correct or needs review?

The forced type assertion may just need a review of the types not to be null.

```js
// forced type assertion, could be null?
200: const { isValid, reason } = isTokensOidcValid(tokens, nonce, currentDatabaseElement.oidcServerConfiguration as OidcServerConfiguration); 
399: return fetchPromise.then(hideTokens(currentDatabase as OidcConfig));

//expects promise, but is void response
343: event.waitUntil(event.respondWith(fetch(newRequest)));
444: event.waitUntil(event.respondWith(maPromesse));
```

can these be written as
```ts
event.waitUntil(fetch(newRequest));
event.waitUntil(maPromesse);
```

EDIT: Ok i see that just `event.WaitUntil` seems to break things , respondWith `appears ok` 
```ts
event.respondWith(fetch(newRequest));
event.respondWith(maPromesse);
```


or is there some special purpose to the code?
