### PR TITLE
fix(serviceworker): Copy prop service_worker_convert_all_requests_to_cors

### DIFF
--- a/packages/react/src/oidc/vanilla/initWorker.ts
+++ b/packages/react/src/oidc/vanilla/initWorker.ts
@@ -200,7 +200,14 @@ export const initWorkerAsync = async(serviceWorkerRelativeUrl, configurationName
     const initAsync = async (oidcServerConfiguration, where, oidcConfiguration:OidcConfiguration) => {
         const result = await sendMessageAsync(registration)({
             type: 'init',
-            data: { oidcServerConfiguration, where, oidcConfiguration: { token_renew_mode: oidcConfiguration.token_renew_mode } },
+            data: {
+                oidcServerConfiguration,
+                where,
+                oidcConfiguration: {
+                    token_renew_mode: oidcConfiguration.token_renew_mode,
+                    service_worker_convert_all_requests_to_cors: oidcConfiguration.service_worker_convert_all_requests_to_cors,
+                },
+            },
             configurationName,
         });
         // @ts-ignore


### PR DESCRIPTION
Ensure the prop `oidcConfiguration.service_worker_convert_all_requests_to_cors`  is copied when constructing oidcConfiguration
May resolve #982 and #974 (when configured with the prop set true)

Question: What should the `default` value `service_worker_convert_all_requests_to_cors` ?
Setting it true would avoid the error being reported, would that be considered the default/preferred configuration?


