### PR TITLE
fix: parsing for magiclink failure that shows error UI

### DIFF
--- a/packages/react/src/oidc/vanilla/initSession.ts
+++ b/packages/react/src/oidc/vanilla/initSession.ts
@@ -50,7 +50,7 @@ export const initSession = (configurationName, storage = sessionStorage) => {
     const getLoginParams = (configurationName) => {
         const dataString = storage[`oidc.login.${configurationName}`];
         if (!getLoginParamsCache) {
-            getLoginParamsCache = JSON.parse(dataString);
+            getLoginParamsCache = JSON.parse(dataString || '{}');
         }
         return getLoginParamsCache;
     };


### PR DESCRIPTION
Not sure, if this is a 100% fix, but this works in our local when npm linked. Feel free to discard this change if this isnt the right implementation